### PR TITLE
Update to support AQARA switch to wireless function

### DIFF
--- a/custom_components/xiaomi_gateway3/utils.py
+++ b/custom_components/xiaomi_gateway3/utils.py
@@ -61,9 +61,12 @@ DEVICES = [{
         # ['0.14.85', None, '?', 'sensor'],  # 5.01, 6.13
         ['4.1.85', 'channel_0', 'channel 1', 'switch'],
         ['4.2.85', 'channel_1', 'channel 2', 'switch'],
+        ['4.10.85', None, 'open_button_1', 'switch'],
+        ['4.11.85', None, 'open_button_2', 'switch'],
         # [?, 'enable_motor_mode', 'interlock', None]
         ['13.1.85', None, 'button_1', None],
         ['13.2.85', None, 'button_2', None],
+        ['13.5.85', None, 'button_1_2', None],
         [None, None, 'action', 'sensor'],
     ]
 }, {
@@ -72,7 +75,9 @@ DEVICES = [{
     'lumi.switch.b1lacn02': ["Aqara", "D1 Wall Single Switch", "QBKG21LM"],
     'params': [
         ['4.1.85', 'channel_0', 'switch', 'switch'],  # or neutral_0?
-        ['13.1.85', None, 'action', 'sensor'],
+        ['4.10.85', None, 'open_button_1', 'switch'],
+        ['13.1.85', None, 'button_1', None],
+        [None, None, 'action', 'sensor'],
     ]
 }, {
     # dual channel on/off
@@ -81,8 +86,11 @@ DEVICES = [{
     'params': [
         ['4.1.85', 'channel_0', 'channel 1', 'switch'],
         ['4.2.85', 'channel_1', 'channel 2', 'switch'],
+        ['4.10.85', None, 'open_button_1', 'switch'],
+        ['4.11.85', None, 'open_button_2', 'switch'],
         ['13.1.85', None, 'button_1', None],
         ['13.2.85', None, 'button_2', None],
+        ['13.5.85', None, 'button_1_2', None],
         [None, None, 'action', 'sensor'],
     ]
 }, {
@@ -92,9 +100,15 @@ DEVICES = [{
         ['4.1.85', 'channel_0', 'channel 1', 'switch'],
         ['4.2.85', 'channel_1', 'channel 2', 'switch'],
         ['4.3.85', 'channel_2', 'channel 3', 'switch'],
+        ['4.10.85', None, 'open_button_1', 'switch'],
+        ['4.11.85', None, 'open_button_2', 'switch'],
+        ['4.12.85', None, 'open_button_3', 'switch'],
         ['13.1.85', None, 'button_1', None],
         ['13.2.85', None, 'button_2', None],
         ['13.3.85', None, 'button_3', None],
+        ['13.5.85', None, 'button_1_2', None],
+        ['13.6.85', None, 'button_1_3', None],
+        ['13.7.85', None, 'button_2_3', None],
         [None, None, 'action', 'sensor'],
     ]
 }, {
@@ -106,9 +120,15 @@ DEVICES = [{
         ['4.1.85', 'channel_0', 'channel 1', 'switch'],
         ['4.2.85', 'channel_1', 'channel 2', 'switch'],
         ['4.3.85', 'channel_2', 'channel 3', 'switch'],
+        ['4.10.85', None, 'open_button_1', 'switch'],
+        ['4.11.85', None, 'open_button_2', 'switch'],
+        ['4.12.85', None, 'open_button_3', 'switch'],
         ['13.1.85', None, 'button_1', None],
         ['13.2.85', None, 'button_2', None],
         ['13.3.85', None, 'button_3', None],
+        ['13.5.85', None, 'button_1_2', None],
+        ['13.6.85', None, 'button_1_3', None],
+        ['13.7.85', None, 'button_2_3', None],
         [None, None, 'action', 'sensor'],
     ]
 }, {


### PR DESCRIPTION
Update to support AQARA switch to wireless function
1. Support AQARA switch to wireless function, sync with Mijia APP
2. Support wireless events as sensors (Single-key，Multi-key)

example:
Sensor action:
button_1_single
button_1_2_quadruple