### PR TITLE
Support for mesh switches

### DIFF
--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -327,6 +327,20 @@ def parse_xiaomi_mesh(data: list):
     return result
 
 
+def parse_xiaomi_mesh_callback(data: list):
+    result = []
+
+    for payload in data:
+        if payload.get('code', 1) != 1:
+            continue
+    
+        result.append([
+            payload['did'], payload['siid'], payload['piid'],
+        ])
+
+    return result
+    
+
 def pack_xiaomi_mesh(did: str, data: Union[dict, list]):
     if isinstance(data, dict):
         return [{

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -312,7 +312,7 @@ def parse_xiaomi_mesh(data: list):
             continue
 
         did = payload['did']
-        if did in BLE_MESH_SWITCHES:
+        if payload['model'] in BLE_MESH_SWITCHES:
             # handle response for BLE mesh switches
             # a tuple of (siid, piid) is used as the key
             key = (payload['siid'], payload['piid'])

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -28,8 +28,8 @@ DEVICES = {
     # Mesh Switches
     1946: ["Xiaomi", "Mesh Wall Double Switch", "DHKG02ZM"],
     2007: ["Unknown", "Mesh Switch Controller", "2007"],
-    2093: ["PTX", "PTX Mesh Wall Triple Switch","PTX-TK3/M"],
-    2257: ["PTX", "PTX Mesh Wall Double Switch", "PTX-SK2M"],
+    2093: ["PTX", "Mesh Wall Triple Switch","PTX-TK3/M"],
+    2257: ["PTX", "Mesh Wall Double Switch", "PTX-SK2M"],
     # Mesh Group
     0: ["Mesh", "Mesh Group"]
 }

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -28,18 +28,13 @@ DEVICES = {
     # Mesh Switches
     1946: ["Xiaomi", "Mesh Wall Double Switch", "DHKG02ZM"],
     2007: ["Unknown", "Mesh Switch Controller", "2007"],
-    2093: ["PTX", "Mesh Wall Triple Switch","PTX-TK3/M"],
+    2093: ["PTX", "Mesh Wall Triple Switch", "PTX-TK3/M"],
     2257: ["PTX", "Mesh Wall Double Switch", "PTX-SK2M"],
+    2258: ["PTX", "Mesh Wall Single Switch", "PTX-SK1M"],
     # Mesh Group
     0: ["Mesh", "Mesh Group"]
 }
 
-BLE_MESH_SWITCHES = [
-    1946,
-	2007,
-    2093,
-	2257
-]
 
 # model: [
 #   [siid, piid, name, on_value, off_value],
@@ -50,6 +45,9 @@ BLE_SWITCH_DEVICES_PROPS = {
     1946: [
         [2, 1, 'Left Switch', True, False],
         [3, 1, 'Right Switch', True, False],
+    ],
+    2007: [
+        [2, 1, None, True, False]
     ],
     2093: [
         [2, 1, 'Left Switch', True, False],
@@ -66,11 +64,13 @@ BLE_SWITCH_DEVICES_PROPS = {
         [8, 1, 'Backlight', 1, 0],
         [8, 2, 'Left - Always On', 1, 0],
         [8, 3, 'Right - Always On', 1, 0],
+    ],
+    2258: [
+        [2, 1, 'Switch', True, False],
+        [8, 1, 'Backlight', 1, 0],
+        [8, 2, 'Always On', 1, 0],
     ]
 }
-DEFAULT_SWITCH_PROP = [
-	[2, 1, None, True, False]
-]
 
 BLE_FINGERPRINT_ACTION = [
     "Match successful", "Match failed", "Timeout", "Low quality",
@@ -321,7 +321,7 @@ def parse_xiaomi_mesh(data: list):
             continue
 
         did = payload['did']
-        if payload['model'] in BLE_MESH_SWITCHES:
+        if payload['model'] in BLE_SWITCH_DEVICES_PROPS.keys():
             # handle response for BLE mesh switches
             # a tuple of (siid, piid) is used as the key
             key = (payload['siid'], payload['piid'])

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -350,7 +350,7 @@ def pack_xiaomi_mesh(did: str, data: Union[dict, list]):
                 'siid': k[0],
                 'piid': k[1],
                 'value': v
-            } for k, v in data.items()]
+            } for k, v in data.items() if k != 'is_switch']
 
         return [{
             'did': did,

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -51,6 +51,15 @@ BLE_SWITCH_DEVICES_PROPS = {
         [2, 1, 'Left Switch', True, False],
         [3, 1, 'Right Switch', True, False],
     ],
+    2093: [
+        [2, 1, 'Left Switch', True, False],
+        [3, 1, 'Middle Switch', True, False],
+        [4, 1, 'Right Switch', True, False],
+        [8, 1, 'Backlight', 1, 0],
+        [8, 2, 'Left - Always On', 1, 0],
+        [8, 3, 'Middle - Always On', 1, 0],
+        [8, 4, 'Right - Always On', 1, 0]
+    ],
     2257: [
         [2, 1, 'Left Switch', True, False],
         [3, 1, 'Right Switch', True, False],

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -12,7 +12,7 @@ DEVICES = {
     1371: ["Xiaomi", "TH Sensor 2", "LYWSD03MMC"],
     1398: ["Xiaomi", "Alarm Clock", "CGD1"],
     1694: ["Aqara", "Door Lock N100", "ZNMS16LM"],
-    1747: ["Xaiomi", "ZenMeasure Clock", "MHO-C303"],
+    1747: ["Xiaomi", "ZenMeasure Clock", "MHO-C303"],
     1983: ["Yeelight", "Button S1", "YLAI003"],
     2038: ["Xiaomi", "Night Light 2", "MJYD02YL-A"],
     2443: ["Xiaomi", "Door Sensor 2", "MCCGQ02HL"],

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -343,6 +343,15 @@ def parse_xiaomi_mesh_callback(data: list):
 
 def pack_xiaomi_mesh(did: str, data: Union[dict, list]):
     if isinstance(data, dict):
+        if data['is_switch'] == True:
+            # for mesh switches, key of the dict is a tuple of (siid, piid)
+            return [{
+                'did': did,
+                'siid': k[0],
+                'piid': k[1],
+                'value': v
+            } for k, v in data.items()]
+
         return [{
             'did': did,
             'siid': 2,

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -60,7 +60,7 @@ BLE_SWITCH_DEVICES_PROPS = {
     ]
 }
 DEFAULT_SWITCH_PROP = [
-	[2, 1, 'Switch', True, False]
+	[2, 1, None, True, False]
 ]
 
 BLE_FINGERPRINT_ACTION = [

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -25,9 +25,43 @@ DEVICES = {
     1772: ["Xiaomi", "Mesh Downlight", "MJTS01YL"],
     2076: ["Yeelight", "Mesh Downlight M2", "YLTS02YL/YLTS04YL"],
     2342: ["Yeelight", "Mesh Bulb M2", "YLDP25YL/YLDP26YL"],
+    # Mesh Switches
+    1946: ["Xiaomi", "Mesh Wall Double Switch", "DHKG02ZM"],
+    2007: ["Unknown", "Mesh Switch Controller", "2007"],
+    2093: ["PTX", "PTX Mesh Wall Triple Switch","PTX-TK3/M"],
+    2257: ["PTX", "PTX Mesh Wall Double Switch", "PTX-SK2M"],
     # Mesh Group
     0: ["Mesh", "Mesh Group"]
 }
+
+BLE_MESH_SWITCHES = [
+    1946,
+	2007,
+    2093,
+	2257
+]
+
+# model: [
+#   [siid, piid, name, on_value, off_value],
+#   [siid, piid, name, on_value, off_value],
+#   ...
+# ]
+BLE_SWITCH_DEVICES_PROPS = {
+    1946: [
+        [2, 1, 'Left Switch', True, False],
+        [3, 1, 'Right Switch', True, False],
+    ],
+    2257: [
+        [2, 1, 'Left Switch', True, False],
+        [3, 1, 'Right Switch', True, False],
+        [8, 1, 'Backlight', 1, 0],
+        [8, 2, 'Left - Always On', 1, 0],
+        [8, 3, 'Right - Always On', 1, 0],
+    ]
+}
+DEFAULT_SWITCH_PROP = [
+	[2, 1, 'Switch', True, False]
+]
 
 BLE_FINGERPRINT_ACTION = [
     "Match successful", "Match failed", "Timeout", "Low quality",

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -308,12 +308,21 @@ def parse_xiaomi_mesh(data: list):
     result = {}
 
     for payload in data:
-        if payload['siid'] != 2 or payload.get('code', 0) != 0:
+        if payload.get('code', 0) != 0:
             continue
 
         did = payload['did']
-        key = MESH_PROPS[payload['piid']]
-        result.setdefault(did, {})[key] = payload['value']
+        if did in BLE_MESH_SWITCHES:
+            # handle response for BLE mesh switches
+            # a tuple of (siid, piid) is used as the key
+            key = (payload['siid'], payload['piid'])
+            result.setdefault(did, {})[key] = payload['value']
+        else:
+            if payload['siid'] != 2:
+                continue
+
+            key = MESH_PROPS[payload['piid']]
+            result.setdefault(did, {})[key] = payload['value']
 
     return result
 

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -352,7 +352,7 @@ def parse_xiaomi_mesh_callback(data: list):
 
 def pack_xiaomi_mesh(did: str, data: Union[dict, list]):
     if isinstance(data, dict):
-        if data['is_switch'] == True:
+        if data.get('is_switch', False):
             # for mesh switches, key of the dict is a tuple of (siid, piid)
             return [{
                 'did': did,

--- a/custom_components/xiaomi_gateway3/core/gateway3.py
+++ b/custom_components/xiaomi_gateway3/core/gateway3.py
@@ -769,6 +769,10 @@ class Gateway3(Thread, GatewayV):
 
     def send_mesh(self, device: dict, data: dict):
         did = device['did']
+
+        if device['model'] in bluetooth.BLE_MESH_SWITCHES:
+            data['is_switch'] = True
+            
         payload = bluetooth.pack_xiaomi_mesh(did, data)
         try:
             return self.miio.send('set_properties', payload)

--- a/custom_components/xiaomi_gateway3/core/gateway3.py
+++ b/custom_components/xiaomi_gateway3/core/gateway3.py
@@ -458,15 +458,14 @@ class Gateway3(Thread, GatewayV):
                 
                 model = device['model']
 
-                domain = 'switch' if model in bluetooth.BLE_MESH_SWITCHES else 'light'
+                domain = 'switch' if model in bluetooth.BLE_SWITCH_DEVICES_PROPS.keys() else 'light'
 
                 # wait domain init
                 while domain not in self.setups:
                     time.sleep(1)
 
                 if domain == 'switch':
-                    props = bluetooth.BLE_SWITCH_DEVICES_PROPS.get(device['model'], bluetooth.DEFAULT_SWITCH_PROP)
-                    for prop in props:
+                    for prop in bluetooth.BLE_SWITCH_DEVICES_PROPS[model]:
                         switch_device = {'mesh_prop': prop}
                         switch_device.update(device)
                         self.setups[domain](self, switch_device, domain)
@@ -786,7 +785,7 @@ class Gateway3(Thread, GatewayV):
     def send_mesh(self, device: dict, data: dict):
         did = device['did']
 
-        if device['model'] in bluetooth.BLE_MESH_SWITCHES:
+        if device['model'] in bluetooth.BLE_SWITCH_DEVICES_PROPS.keys():
             data['is_switch'] = True
 
         payload = bluetooth.pack_xiaomi_mesh(did, data)

--- a/custom_components/xiaomi_gateway3/core/gateway3.py
+++ b/custom_components/xiaomi_gateway3/core/gateway3.py
@@ -701,6 +701,11 @@ class Gateway3(Thread, GatewayV):
         # not always Mesh devices
         self.debug(f"Process Mesh* {data}")
 
+        for msg in data:
+            device = self.devices[msg['did']]
+            if device:
+                msg['model'] = device['model']
+
         data = bluetooth.parse_xiaomi_mesh(data)
         for did, payload in data.items():
             if did in self.updates:

--- a/custom_components/xiaomi_gateway3/switch.py
+++ b/custom_components/xiaomi_gateway3/switch.py
@@ -1,10 +1,12 @@
 import logging
 
+from functools import partial
 from homeassistant.components import persistent_notification
 from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.helpers.entity import ToggleEntity
 
 from . import DOMAIN, Gateway3Device
+from .core import bluetooth
 from .core.gateway3 import Gateway3
 
 _LOGGER = logging.getLogger(__name__)
@@ -12,11 +14,12 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     def setup(gateway: Gateway3, device: dict, attr: str):
-        async_add_entities([
-            FirmwareLock(gateway, device, attr)
-            if attr == 'firmware lock' else
-            Gateway3Switch(gateway, device, attr)
-        ])
+        if attr == 'firmware lock':
+            async_add_entities([FirmwareLock(gateway, device, attr)])
+        elif device['type'] == 'mesh':
+            async_add_entities([Gateway3MeshSwitch(gateway, device, attr)])
+        else:
+            async_add_entities([Gateway3Switch(gateway, device, attr)])
 
     gw: Gateway3 = hass.data[DOMAIN][config_entry.entry_id]
     gw.add_setup('switch', setup)
@@ -41,6 +44,102 @@ class Gateway3Switch(Gateway3Device, ToggleEntity):
 
     def turn_off(self):
         self.gw.send(self.device, {self._attr: 0})
+
+
+class Gateway3MeshSwitch(Gateway3Device, ToggleEntity):
+
+    _siid = 0
+    _piid = 0
+    _on_value = None
+    _off_value = None
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        
+        if 'childs' in self.device:
+            for did in self.device['childs']:
+                self.gw.add_update(did, self.update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        await super().async_will_remove_from_hass()
+
+        if 'childs' in self.device:
+            for did in self.device['childs']:
+                self.gw.remove_update(did, self.update)
+
+    def __init__(self, gateway: Gateway3, device: dict, attr: str):
+        super(Gateway3MeshSwitch, self).__init__(gateway, device, attr)
+
+        mesh_prop = device['mesh_prop']
+
+        self._siid = mesh_prop[0]
+        self._piid = mesh_prop[1]
+        self._on_value = mesh_prop[3]
+        self._off_value = mesh_prop[4]
+        
+        self._unique_id = f"{self.device['mac']}_{self._siid}_{self._piid}_{self._attr}"
+        self._name = (self.device['device_name'] + ' ' +
+                      mesh_prop[2].title())
+
+        self.entity_id = f"{DOMAIN}.{self._unique_id}"
+
+    @property
+    def should_poll(self) -> bool:
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return self._state
+
+    def update(self, data: dict = None):
+        if data is None:
+            did = (self.device['childs'][0]
+                   if 'childs' in self.device
+                   else self.device['did'])
+
+            try:
+                payload = [{'did': did,'siid': self._siid,'piid': self._piid,}]
+                resp = self.gw.miio.send('get_properties', payload)
+                # _LOGGER.debug(f"{self.gw.host} | {did} resp = {resp}")
+                data = bluetooth.parse_xiaomi_mesh(resp)[did]
+            except Exception as e:
+                _LOGGER.debug(f"{self.gw.host} | {did} poll error: {e}")
+                self.device['online'] = False
+                return
+
+            self._update(data)
+
+        else:
+            self._update(data)
+            self.async_write_ha_state()
+
+
+    def _update(self, data: dict):
+        self.device['online'] = True
+        # _LOGGER.debug(f"{self.gw.host} | {self.device['did']}_{self._siid}_{self._piid} _update: {data}")
+        key = (self._siid, self._piid)
+        if key in data:
+            self._state = data[key] == self._on_value
+        
+    async def async_turn_on(self):
+        await self.async_send_mesh_command(self._on_value)
+
+    async def async_turn_off(self):
+        await self.async_send_mesh_command(self._off_value)
+        
+    async def async_send_mesh_command(self, value):
+        try:
+            payload = {(self._siid, self._piid): value}
+            result = await self.hass.async_add_executor_job(
+                partial(self.gw.send_mesh, self.device, payload))
+
+            for data in bluetooth.parse_xiaomi_mesh_callback(result):
+                _LOGGER.debug(f"{self.gw.host} | handle callback: {data}")
+                if data[0] == self.device['did'] and data[1] == self._siid and data[2] == self._piid:
+                    self._state = value == self._on_value
+                    return
+        except Exception as e:
+            _LOGGER.debug(f"{self.gw.host} | failed to handle async command: {e}")
 
 
 class FirmwareLock(Gateway3Switch):

--- a/custom_components/xiaomi_gateway3/switch.py
+++ b/custom_components/xiaomi_gateway3/switch.py
@@ -78,9 +78,9 @@ class Gateway3MeshSwitch(Gateway3Device, ToggleEntity):
         self._on_value = mesh_prop[3]
         self._off_value = mesh_prop[4]
         
-        self._unique_id = f"{self.device['mac']}_{self._siid}_{self._piid}_{self._attr}"
+        self._unique_id = f"{self.device['mac']}_{self._siid}_{self._piid}"
         self._name = (self.device['device_name'] + ' ' +
-                      mesh_prop[2].title())
+                      mesh_prop[2].title()) if mesh_prop[2] is not None else self.device['device_name']
 
         self.entity_id = f"{DOMAIN}.{self._unique_id}"
 


### PR DESCRIPTION
I've reworked on the code for supporting mesh switches. I assume the code is much better than my previous terrible PR #98 , and would be easier to review, hopefully.
 
The mesh switches supported:

- Model 1946 (Xiaomi 2-key wall switch)
- Model 2007 (basically a single relay)
- Model 2093 (PTX 3-key wall switch)
- Model 2257 (PTX 2-key wall switch)
- Model 2258 (PTX single-key wall switch)