### PR TITLE
Add new BLE device: Mi Smart Electrical Outlet

### DIFF
--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -85,6 +85,12 @@ DEVICES = [{
         [8, 1, 'backlight', 'switch'],
         [8, 2, 'smart', 'switch'],
     ]
+},{
+    3083: ["Xiaomi", "Mi Smart Electrical Outlet", "ZNCZ01ZM"],
+    'params': [
+        [2, 1, 'outlet', 'switch'],
+        [4, 1, 'backlight', 'switch'],
+    ]
 }]
 
 BLE_FINGERPRINT_ACTION = [


### PR DESCRIPTION
add   BLE Mesh  DEVICE
device_info     ["Xiaomi", "Mi Smart Electrical Outlet", "ZNCZ01ZM"] 
https://www.mi.com/buy/detail?product_id=13418
Setup Mesh device {'did': 'xxxxx', 'mac': 'xxxx', 'model': 3083, 'type': 'mesh', 'device_name': 'Mesh', 'device_model': 3083, 'params': [[2, 1, 'light', 'light'], [2, 2, 'brightness', None], [2, 3, 'color_temp', None]]}
##  ON
Process props [{'did': 'xxxxx', 'siid': 2, 'piid': 1, 'value': True, 'tid': 159}]
##  OFF
Process props [{'did': 'xxxxx', 'siid': 2, 'piid': 1, 'value': False, 'tid': 158}]
##  outlet power   (value/100)W   Not finished yet
Process props [{'did': 'xxxxx', 'siid': 3, 'piid': 1, 'value': 357, 'tid': 162}] 
## backlight
Process props [{'did': 'xxxxx', 'siid': 4, 'piid': 1, 'value': True, 'tid': 181}]