### PR TITLE
Fix situation when integration devices unavailable

### DIFF
--- a/custom_components/xiaomi_gateway3/core/gateway3.py
+++ b/custom_components/xiaomi_gateway3/core/gateway3.py
@@ -605,6 +605,9 @@ class Gateway3(Thread, GatewayMesh, GatewayStats):
                 dev_list = json.loads(data.get('dev_list', 'null')) or []
 
                 for did in dev_list:
+                    if did + '.model' not in data:
+                        self.debug(f"{did} has not in devices DB")
+                        continue
                     model = data[did + '.model']
                     desc = zigbee.get_device(model)
 


### PR DESCRIPTION
Today, all devise in this integration stay unavailable for me. After some debug I understood that problem in Aqara water leak sensor that unavailable in MiHome (maybe battery problem, I dont know why. Not in network error). This fix help me with my problem. Sorry for my english. 