### PR TITLE
Added password input for firmware 1.5.0_0027

### DIFF
--- a/custom_components/xiaomi_gateway3/core/shell.py
+++ b/custom_components/xiaomi_gateway3/core/shell.py
@@ -58,7 +58,11 @@ class TelnetShell(Telnet):
 
         raw = self.read_until(b"\r\n# ", timeout=3)
         if b'Password:' in raw:
-            raise Exception("Telnet with password don't supported")
+            self.write(b"admin\n")
+
+            raw = self.read_until(b"\r\n# ", timeout=3)
+            if b'Login incorrect' in raw:
+                raise Exception("Telnet with standard password failed")
 
         self.ver = self.get_version()
 

--- a/custom_components/xiaomi_gateway3/core/zigbee.py
+++ b/custom_components/xiaomi_gateway3/core/zigbee.py
@@ -428,6 +428,17 @@ DEVICES = [{
         ['9.1', None, 'button_both: 4', None],
         [None, None, 'action', 'sensor'],
     ]
+}, {
+    # https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:curtain:0000A00C:lumi-acn002:1
+    'lumi.curtain.acn002': ["Aqara", "Roller Shade E1", "ZNJLBL01LM"],
+    'miot_spec': [
+        # ['2.1', '2.1', 'fault', None],
+        ['2.2', None, 'motor', 'cover'],
+        # ['2.4', '2.4', 'target_position', None],
+        ['2.5', '2.5', 'position', None],
+        ['2.6', '2.6', 'run_state', None],
+        ['3.4', '3.4', 'battery', 'sensor'],
+    ]
 }]
 
 GLOBAL_PROP = {

--- a/custom_components/xiaomi_gateway3/cover.py
+++ b/custom_components/xiaomi_gateway3/cover.py
@@ -10,12 +10,15 @@ from .core.helpers import XiaomiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-RUN_STATES = [STATE_CLOSING, STATE_OPENING, None]
+RUN_STATES = {0: STATE_CLOSING, 1: STATE_OPENING}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     def setup(gateway: Gateway3, device: dict, attr: str):
-        async_add_entities([XiaomiCover(gateway, device, attr)])
+        if device.get('lumi_spec'):
+            async_add_entities([XiaomiCover(gateway, device, attr)])
+        else:
+            async_add_entities([XiaomiCoverMIOT(gateway, device, attr)])
 
     gw: Gateway3 = hass.data[DOMAIN][config_entry.entry_id]
     gw.add_setup('cover', setup)
@@ -59,3 +62,14 @@ class XiaomiCover(XiaomiEntity, CoverEntity):
     def set_cover_position(self, **kwargs):
         position = kwargs.get(ATTR_POSITION)
         self.gw.send(self.device, {'position': position})
+
+
+class XiaomiCoverMIOT(XiaomiCover):
+    def open_cover(self, **kwargs):
+        self.gw.send(self.device, {'motor': 2})
+
+    def close_cover(self, **kwargs):
+        self.gw.send(self.device, {'motor': 1})
+
+    def stop_cover(self, **kwargs):
+        self.gw.send(self.device, {'motor': 0})


### PR DESCRIPTION
I've upgraded to firmware 1.5.0_0027 before using Home Assistant, now the login asks for a password, 'admin' works fine.

I changed it using `passwd` to another one, doesn't seem to be a problem for the xiaomi app.
Data of all my miaomiaoce.sensor_ht.h1 and miaomiaoce.sensor_ht.t2 sensors are now also received in Home Assistant.
Zigbee is used in my case in Zigbee Home Automation (ZHA) mode to connect to Megos LIGHTWAY bulb and remote (TuYa-based), which also works fine.