### PR TITLE
feature:Support Xiaomi Mesh Wall Single/Double Switch(ZNKG01HL/ZNKG02HL)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -115,6 +115,14 @@ DEVICES = [{
         [6, 1, 'humidity', 'sensor'],
         [6, 7, 'temperature', 'sensor'],
     ]
+}, {
+    2716: ["Xiaomi", "Mesh Wall Double Switch", "ZNKG02HL"],
+    'miot_spec': [
+        [2, 1, 'left_switch', 'switch'],
+        [3, 1, 'right_switch', 'switch'],
+        [6, 1, 'humidity', 'sensor'],
+        [6, 7, 'temperature', 'sensor'],
+    ]
 }]
 
 # if color temp not default 2700..6500

--- a/custom_components/xiaomi_gateway3/core/bluetooth.py
+++ b/custom_components/xiaomi_gateway3/core/bluetooth.py
@@ -108,6 +108,13 @@ DEVICES = [{
         [3, 1, 'power', 'sensor'],
         [4, 1, 'backlight', 'switch'],
     ]
+}, {
+   2715: ["Xiaomi", "Mesh Wall Single Switch", "ZNKG01HL"],
+    'miot_spec': [
+        [2, 1, 'switch', 'switch'],
+        [6, 1, 'humidity', 'sensor'],
+        [6, 7, 'temperature', 'sensor'],
+    ]
 }]
 
 # if color temp not default 2700..6500


### PR DESCRIPTION
logs from debug mode:
```
2021-08-22 15:34:51  DEBUG    gateway3      192.168.124.153 | Setup mesh device {'did': '1043814689', 'mac': '****', 'model': 2715, 'type': 'mesh', 'online': False}
2021-08-22 15:38:03  DEBUG    gateway3      192.168.124.153 | Pull Mesh [ {'did': '1043814689', 'siid': 2, 'piid': 1, 'value': False, 'code': 0, 'ts': 1629617801, 'ret': 0}]
2021-08-22 15:38:26  DEBUG    gateway3      192.168.124.153 | Process props [{'did': '1043814689', 'siid': 6, 'piid': 1, 'tid': 165, 'value': 63.100002}]
2021-08-22 15:38:27  DEBUG    gateway3      192.168.124.153 | Process props [{'did': '1043814689', 'siid': 6, 'piid': 7, 'tid': 166, 'value': 29.700001}]
```