### PR TITLE
Fix: ValueError when the device_model parameter does not contain spaces

### DIFF
--- a/custom_components/xiaomi_gateway3/core/zigbee.py
+++ b/custom_components/xiaomi_gateway3/core/zigbee.py
@@ -643,7 +643,7 @@ def fix_xiaomi_battery(value: int) -> int:
 
 
 def get_buttons(device_model: str):
-    zigbee_model, _ = device_model.split(' ', 1)
+    zigbee_model = device_model.split(' ', 1)[0]
     for device in DEVICES:
         if zigbee_model not in device:
             continue


### PR DESCRIPTION
Fixed this issue.

Log with error:

  File "/home/ha/.homeassistant/custom_components/xiaomi_gateway3/core/zigbee.py", line 654, in get_buttons
    zigbee_model, _ = device_model.split(' ', 1)
ValueError: not enough values to unpack (expected 2, got 1)

