### PR TITLE
Update xiaomi_cloud.py to use RC4

### DIFF
--- a/custom_components/xiaomi_gateway3/core/xiaomi_cloud.py
+++ b/custom_components/xiaomi_gateway3/core/xiaomi_cloud.py
@@ -108,7 +108,12 @@ class MiCloud:
         return service_token
 
     async def get_devices(self):
-        payload = {'getVirtualModel': False, 'getHuamiDevices': 0}
+        payload = {
+            "getVirtualModel": True,
+            "getHuamiDevices": 1,
+            "get_split_device": False,
+            "support_smart_home": True
+        }
 
         total = []
         for server in self.servers:
@@ -148,23 +153,31 @@ class MiCloud:
 
         nonce = gen_nonce()
         signed_nonce = gen_signed_nonce(self.auth['ssecurity'], nonce)
-        signature = gen_signature(url, signed_nonce, nonce, data)
 
         try:
+            params = {
+                'data': data
+            }
+            params['rc4_hash__'] = gen_signature(url, signed_nonce, params)
+            params = {k:encrypt_rc4(signed_nonce, v) for (k,v) in params.items()}
+            params.update({
+                'signature': gen_signature(url, signed_nonce, params),
+                'ssecurity': self.auth['ssecurity'],
+                '_nonce': nonce
+            })
             r = await self.session.post(baseurl + url, cookies={
                 'userId': self.auth['user_id'],
                 'serviceToken': self.auth['service_token'],
                 'locale': 'en_US'
             }, headers={
+                'Accept-Encoding': 'identity',
                 'User-Agent': UA,
-                'x-xiaomi-protocal-flag-cli': 'PROTOCAL-HTTP2'
-            }, data={
-                'signature': signature,
-                '_nonce': nonce,
-                'data': data
-            }, timeout=10)
+                'x-xiaomi-protocal-flag-cli': 'PROTOCAL-HTTP2',
+                'MIOT-ENCRYPT-ALGORITHM': 'ENCRYPT-RC4'
+            }, data=params, timeout=10)
 
-            resp = await r.json(content_type=None)
+            resp = await r.text()
+            resp = json.loads(decrypt_rc4(signed_nonce, resp))
             # _LOGGER.debug(f"Response from MIoT API {url}: {resp}")
             assert resp['code'] == 0, resp
             return resp['result']
@@ -176,6 +189,46 @@ class MiCloud:
 
         return None
 
+class RC4:
+    _idx = 0
+    _jdx = 0
+    _ksa: list
+
+    def __init__(self, pwd):
+        self.init_key(pwd)
+
+    def init_key(self, pwd):
+        cnt = len(pwd)
+        ksa = list(range(256))
+        j = 0
+        for i in range(256):
+            j = (j + ksa[i] + pwd[i % cnt]) & 255
+            ksa[i], ksa[j] = ksa[j], ksa[i]
+        self._ksa = ksa
+        self._idx = 0
+        self._jdx = 0
+        return self
+
+    def crypt(self, data):
+        if isinstance(data, str):
+            data = data.encode()
+        ksa = self._ksa
+        i = self._idx
+        j = self._jdx
+        out = []
+        for byt in data:
+            i = (i + 1) & 255
+            j = (j + ksa[i]) & 255
+            ksa[i], ksa[j] = ksa[j], ksa[i]
+            out.append(byt ^ ksa[(ksa[i] + ksa[j]) & 255])
+        self._idx = i
+        self._jdx = j
+        self._ksa = ksa
+        return bytearray(out)
+
+    def init1024(self):
+        self.crypt(bytes(1024))
+        return self
 
 def get_random_string(length: int):
     seq = string.ascii_uppercase + string.digits
@@ -196,10 +249,24 @@ def gen_signed_nonce(ssecret: str, nonce: str) -> str:
     return base64.b64encode(m.digest()).decode()
 
 
-def gen_signature(url: str, signed_nonce: str, nonce: str, data: str) -> str:
+def gen_signature(url: str, signed_nonce: str, data: dict) -> str:
     """Request signature based on url, signed_nonce, nonce and data."""
-    sign = '&'.join([url, signed_nonce, nonce, 'data=' + data])
-    signature = hmac.new(key=base64.b64decode(signed_nonce),
-                         msg=sign.encode(),
-                         digestmod=hashlib.sha256).digest()
+    sign = '&'.join(
+        (
+            ['POST', url]
+            + [f"{k}={v}" for k, v in data.items()]
+            + [signed_nonce]
+        )
+    )
+    signature = hashlib.sha1(sign.encode()).digest()
     return base64.b64encode(signature).decode()
+
+
+def encrypt_rc4(pwd, data):
+    return base64.b64encode(
+        RC4(base64.b64decode(pwd.encode())).init1024().crypt(data.encode())
+    ).decode()
+
+
+def decrypt_rc4(pwd, data):
+    return RC4(base64.b64decode(pwd.encode())).init1024().crypt(base64.b64decode(data))


### PR DESCRIPTION
MiHome has been using RC4 for some time for all regions, in the last few days Xiaomi have enforced RC4 on the DE server.
Other servers likely soon. (I imagine DE has lowest # of users, likely a test).

This is a minimal patch, I've not tried to improve any pre-existing code, just fix _this_ issue.

Native RC4 func (borrowed from @al-one) to save any additional package requirements.