### PR TITLE
Adds support Tuya TH sensor (TT001ZAV20)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1019,6 +1019,15 @@ DEVICES += [{
         ZTuyaPlugModeConv("mode", "select", enabled=False),
     ],
 }, {
+    "RH3052": ["Tuya", "TH sensor", "TT001ZAV20"],
+    "support": 3,
+    "spec": [
+        ZTemperatureConv("temperature", "sensor"),
+        ZHumidityConv("humidity", "sensor"),
+        # value always 100%
+        # ZBatteryConv("battery", "sensor"),
+    ],
+}, {
     # very simple relays
     "01MINIZB": ["Sonoff", "Mini", "ZBMINI"],
     "SA-003-Zigbee": ["eWeLink", "Zigbee OnOff Controller", "SA-003-Zigbee"],


### PR DESCRIPTION
Hi!

I added partial support this device https://www.zigbee2mqtt.io/devices/TT001ZAV20.html

The battery percentage remaining present in the data, but always has same value(z2m has same behavior). 
Looks like it should be commented out in spec. Or should I use flag `enabled=False` in such cases?

Please review my changes. 


<details>
  <summary>Screenshot</summary>  

  ![image](https://user-images.githubusercontent.com/5539462/171989525-246e8846-7edc-4cae-8cf4-7399615343d4.png)  

</details>

