### PR TITLE
Added a new Mesh device:  Xiaomi Smart Power Strip 2 (5 outlets), model: XMZNCXB01QM

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1497,10 +1497,7 @@ DEVICES += [{
     4896: ["Xiaomi", "Mesh Power Strip 2", "XMZNCXB01QM"],
     "spec": [
         Converter("switch", "switch", mi="2.p.1"),  # bool
-        Converter("mode", "switch", mi="2.p.2"),  # int8
-        Converter("temperature", "sensor", mi="2.p.3"),  # float
-        Converter("power-consumption", "power", mi="3.p.1"),  # float
-        Converter("electric-power", "power", mi="3.p.2"),  # float
+        MathConv("temperature", "sensor", mi="2.p.3", round=2),  # float
     ],
 }, {
     3129: ["Xiaomi", "Smart Curtain Motor", "MJSGCLBL01LM"],

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1498,7 +1498,7 @@ DEVICES += [{
     "spec": [
         Converter("switch", "switch", mi="2.p.1"),  # bool
         Converter("mode", "switch", mi="2.p.2"), # int8
-        MathConv("temperature", "sensor", mi="2.p.3", round=2),  # float
+        MathConv("chip_temperature", "sensor", mi="2.p.3", round=2),  # float
         MathConv("power_consumption", "sensor", mi="3.p.1", round=2),  # float
         MathConv("electric_power", "sensor", mi="3.p.2", round=2)  # float
     ]

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1493,6 +1493,16 @@ DEVICES += [{
         BoolConv("light", "binary_sensor", mi="3.p.1")  # uint8 0-Dark 1-Bright
     ],
 }, {
+    # urn:miot-spec-v2:device:outlet:0000A002:qmi-psv3:1:0000C816小米智能插线板2 5位插孔
+    4896: ["Xiaomi", "Mesh Power Strip 2", "XMZNCXB01QM"],
+    "spec": [
+        Converter("switch", "switch", mi="2.p.1"),  # bool
+        Converter("mode", "switch", mi="2.p.2"),  # int8
+        Converter("temperature", "sensor", mi="2.p.3"),  # float
+        Converter("power-consumption", "power", mi="3.p.1"),  # float
+        Converter("electric-power", "power", mi="3.p.2"),  # float
+    ],
+}, {
     3129: ["Xiaomi", "Smart Curtain Motor", "MJSGCLBL01LM"],
     "spec": [
         MapConv("motor", "cover", mi="2.p.1", map={

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1497,8 +1497,11 @@ DEVICES += [{
     4896: ["Xiaomi", "Mesh Power Strip 2", "XMZNCXB01QM"],
     "spec": [
         Converter("switch", "switch", mi="2.p.1"),  # bool
+        Converter("mode", "switch", mi="2.p.2"), # int8
         MathConv("temperature", "sensor", mi="2.p.3", round=2),  # float
-    ],
+        MathConv("power_consumption", "sensor", mi="3.p.1", round=2),  # float
+        MathConv("electric_power", "sensor", mi="3.p.2", round=2)  # float
+    ]
 }, {
     3129: ["Xiaomi", "Smart Curtain Motor", "MJSGCLBL01LM"],
     "spec": [


### PR DESCRIPTION
As per #770, I have tested to add the above device and worked!

All I have done is to add the following in `devices.py`:


     {
         # urn:miot-spec-v2:device:outlet:0000A002:qmi-psv3:1:0000C816小米智能插线板2 5位插孔
         4896: ["Xiaomi", "Mesh Power Strip 2", "XMZNCXB01QM"],
         "spec": [
               Converter("switch", "switch", mi="2.p.1"),  # bool
               Converter("mode", "switch", mi="2.p.2"), # int8
               MathConv("chip_temperature", "sensor", mi="2.p.3", round=2),  # float
               MathConv("power_consumption", "sensor", mi="3.p.1", round=2),  # float
               MathConv("electric_power", "sensor", mi="3.p.2", round=2)  # float
         ]
     },

