### PR TITLE
Add devices' support and change cover fix's parameter

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1534,6 +1534,60 @@ DEVICES += [{
         Converter("channel_3", "switch", mi="4.p.1"),
     ],
 }, {
+    6379: ["Xiaomi", "Mesh Wall Switch (Neutral Wire)", "XMQBKG01LM"],
+    "spec": [
+        Converter("switch", "switch", mi="2.p.1"),
+        Converter("led", "switch", mi="7.p.1", enabled=False),
+        BoolConv("wireless", "switch", mi="2.p.2", enabled=False),
+        Converter("action", "sensor", enabled=False),
+        ButtonMIConv("button", mi="6.e.1", value=1),
+        MapConv("device_fault", mi="2.p.3", map={
+            0: "nofaults", 1: "overtemperature", 2: "overload", 3: "overtemperature-overload"
+        }), 
+        ],
+}, {
+    6380: ["Xiaomi", "Mesh Double Wall Switch (Neutral Wire)", "XMQBKG02LM"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+        Converter("led", "switch", mi="5.p.1", enabled=False),
+        BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
+        BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
+        Converter("action", "sensor", enabled=False),
+        ButtonMIConv("button_1", mi="6.e.1", value=1),
+        ButtonMIConv("button_2", mi="7.e.1", value=1),
+        MapConv("device_fault_1", mi="2.p.3", map={
+            0: "nofaults", 1: "overtemperature", 2: "overload", 3: "overtemperature-overload"
+        }),
+        MapConv("device_fault_2", mi="3.p.3", map={
+            0: "nofaults", 1: "overtemperature", 2: "overload", 3: "overtemperature-overload"
+        }),
+    ],
+}, {
+    6381: ["Xiaomi", "Mesh Triple Wall Switch (Neutral Wire)", "XMQBKG03LM"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+        Converter("channel_3", "switch", mi="4.p.1"),
+        Converter("led", "switch", mi="9.p.1", enabled=False),
+        BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
+        BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
+        BoolConv("wireless_3", "switch", mi="4.p.2", enabled=False),
+        Converter("action", "sensor", enabled=False),
+        ButtonMIConv("button_1", mi="6.e.1", value=1),
+        ButtonMIConv("button_2", mi="7.e.1", value=1),
+        ButtonMIConv("button_3", mi="8.e.1", value=1),
+        MapConv("device_fault_1", mi="2.p.3", map={
+            0: "nofaults", 1: "overtemperature", 2: "overload", 3: "overtemperature-overload"
+        }),
+        MapConv("device_fault_2", mi="3.p.3", map={
+            0: "nofaults", 1: "overtemperature", 2: "overload", 3: "overtemperature-overload"
+        }),
+        MapConv("device_fault_3", mi="4.p.3", map={
+            0: "nofaults", 1: "overtemperature", 2: "overload", 3: "overtemperature-overload"
+        }),
+    ],
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1588,6 +1588,17 @@ DEVICES += [{
         }),
     ],
 }, {
+    5195: ["YKGC", "LS Smart Curtain Motor", "LSCL"],
+    "spec": [
+        MapConv("motor", "cover", mi="2.p.1", map={
+            0: "stop", 1: "open", 2: "close"
+            }),
+        Converter("target_position", mi="2.p.6"),
+        CurtainPosConv("position", mi="2.p.2", parent="motor"),
+        Converter("motor_reverse", "switch", mi="2.p.5", enabled=False),
+        BoolConv("on", "switch", mi="2.p.9"),       
+    ],
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool

--- a/custom_components/xiaomi_gateway3/cover.py
+++ b/custom_components/xiaomi_gateway3/cover.py
@@ -38,7 +38,7 @@ class XiaomiCover(XEntity, CoverEntity, RestoreEntity):
         if 'position' in data:
             self._attr_current_cover_position = data['position']
             # https://github.com/AlexxIT/XiaomiGateway3/issues/771
-            self._attr_is_closed = self._attr_current_cover_position <= 1
+            self._attr_is_closed = self._attr_current_cover_position <= 2
 
     @callback
     def async_restore_last_state(self, state: str, attrs: dict):


### PR DESCRIPTION
I added support for Xiaomi Mesh Neutral Wire version wall switch and LS Smart Curtain Motor.
And as is mention in https://github.com/AlexxIT/XiaomiGateway3/commit/fb0c0300f7a870ace672b22e92d63726d584c760 , set the parameter to 2 may be better 🤣