### PR TITLE
feat(devices): Add Aqara Motion Sensor E1

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Aqara|Double Wall Switch H1 EU (no N)|[WS-EUK02](https://home.miot-spec.com/s/lu
 Aqara|Double Wall Switch H1 EU (with N)|[WS-EUK04](https://home.miot-spec.com/s/lumi.switch.n2aeu1)|channel_1, channel_2, energy, power, action, led, led_reverse, power_on_state, wireless_1, wireless_2|
 Aqara|Double Wall Switch US (with N)|[WS-USC04](https://home.miot-spec.com/s/lumi.switch.b2naus01)|channel_1, channel_2, action, energy, power, led, power_on_state, wireless_1, wireless_2|
 Aqara|Motion Sensor|[RTCGQ11LM](https://home.miot-spec.com/s/lumi.sensor_motion.aq2)|motion, illuminance, battery|
+Aqara|Motion Sensor E1|[RTCGQ15LM](https://home.miot-spec.com/s/lumi.motion.acn001)|motion, illuminance, battery|
 Aqara|Opple Four Button CN|[WXCJKG12LM](https://home.miot-spec.com/s/lumi.remote.b486opcn01)|mode, action, battery, battery_low, chip_temperature|
 Aqara|Opple MX480 CN|[XDD13LM](https://home.miot-spec.com/s/lumi.light.cwopcn03)|light|
 Aqara|Opple MX650 CN|[XDD12LM](https://home.miot-spec.com/s/lumi.light.cwopcn02)|light|

--- a/custom_components/xiaomi_gateway3/core/converters/base.py
+++ b/custom_components/xiaomi_gateway3/core/converters/base.py
@@ -328,6 +328,12 @@ class GasSensitivityWriteConv(Converter):
         pass
 
 
+class MotionIlluminanceConv(Converter):
+    def decode(self, device: "XDevice", payload: dict, value: int):
+        payload["motion"] = bool(value)
+        payload.update(**device.decode_lumi(value))
+
+
 class ParentConv(Converter):
     def decode(self, device: "XDevice", payload: dict, value: str):
         try:

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -344,6 +344,16 @@ DEVICES += [{
         Battery, BatteryOrig
     ],
 }, {
+    # motion sensor E1 with illuminance
+    "lumi.motion.acn001": ["Aqara", "Motion Sensor E1", "RTCGQ15LM"],
+    "spec": [
+        MotionIlluminanceConv("motion", "binary_sensor", mi="2.e.1"),
+        Converter("illuminance", "sensor", mi="2.p.1", parent="motion"),
+        BatteryConv("battery", "sensor", mi="3.p.2"),  # voltage, mV
+        MapConv("battery_low", "binary_sensor", mi="3.p.1", map=BATTERY_LOW,
+                enabled=False)
+    ],
+}, {
     # water leak sensor
     "lumi.sensor_wleak.aq1": ["Aqara", "Water Leak Sensor", "SJCGQ11LM"],
     "spec": [

--- a/tests/test_conv_lumi.py
+++ b/tests/test_conv_lumi.py
@@ -81,6 +81,22 @@ def test_sensor_motion():
     assert p == {'illuminance': 6, 'motion': True}
 
 
+def test_sensor_motion_e1():
+    device = XDevice(ZIGBEE, "lumi.motion.acn001", ZDID, ZMAC, ZNWK)
+    assert device.info.name == "Aqara Motion Sensor E1"
+    device.setup_converters()
+
+    p = device.decode_lumi([
+        {"siid": 2, "eiid": 1, "arguments": [{"siid": 2, "piid": 1, "value": 9}]}
+    ])
+    assert p == {"illuminance": 9, "motion": True}
+
+    p = device.decode_lumi([
+        {"siid": 2, "piid": 1, "value": 10, "code": 0}
+    ])
+    assert p == {"illuminance": 10}
+
+
 def test_opple_buttons():
     device = XDevice(ZIGBEE, 'lumi.remote.b686opcn01', ZDID, ZMAC, ZNWK)
     assert device.info.name == 'Aqara Opple Six Button CN'


### PR DESCRIPTION
Aqara Motion Sensor E1 is new Zigbee 3 device, I found it's not in the supported devices list and can't show up in my HA device list.

The illuminance value is nested inside `params -> arguments` reported when there's a motion action.
I'm not sure if there's any better way to parse the illuminance value, but the `MotionIlluminanceConv` can work and pass tests.

NOTE: `entity id` and `did` are masked as `#device_mac#`, `#did#` respectively in the following debug log.

**report cmd:**
```
2022-07-27 21:59:23,325 192.168.10.221 [MQTT] zigbee/send b'{"cmd":"report","id":2000002164,"did":"lumi.#device_mac#","dev_src":"0","time":1658930361963,"rssi":-34,"mi_spec":[{"siid":2,"eiid":1,"arguments":[{"siid":2,"piid":1,"value":58}]}]}'
2022-07-27 21:59:23,328 192.168.10.221 [BASE] binary_sensor.0x#device_mac#_motion | Extend delay: 90 seconds
2022-07-27 21:59:23,334 192.168.10.221 [LUMI] 0x#device_mac# (0x8199) recv {'motion': True, 'illuminance': 58}
2022-07-27 21:59:23,360 192.168.10.221 [MQTT] log/miio b'\x1b[0;32m2022:07:27:21:59:21.713 [D] miio_client_func: ot_agent_recv_handler_one(): fd:9, msg:{"method":"event_occured","params":{"arguments":[{"piid":1,"siid":2,"value":58}],"did":"#did#","eiid":1,"siid":2},"id":42415} length:129 bytes\x1b[0m'
```

**read_rsp cmd:**
```
2022-07-24 23:03:04,980 192.168.10.221 [MQTT] zigbee/send b'{"cmd":"read_rsp"," id":593,"did":"lumi.#device_mac#","dev_src":"0","time":1658674983855,"rssi" :-35,"mi_spec":[{"siid":2,"piid":1,"value":39,"code":0}]}'
2022-07-24 23:03:04,983 192.168.10.221 [LUMI] 0x#device_mac# (0x8199) recv {'illuminance': 39}
```

Thanks for the awesome project, I've spent a few days tweaking my device with this project, it indeed saved my life!