### PR TITLE
Fix overriding deprecated method of NumberEntity

### DIFF
--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -42,7 +42,7 @@ class XiaomiNumber(XEntity, NumberEntity):
     def async_restore_last_state(self, state: float, attrs: dict):
         self._attr_value = state
 
-    async def async_set_value(self, value: float):
+    async def async_set_native_value(self, value: float):
         await self.device_send({self.attr: value})
 
     async def async_update(self):


### PR DESCRIPTION
Currently there is a warning:

> custom_components.xiaomi_gateway3.number::XiaomiNumber is overriding deprecated methods on an instance of NumberEntity, this is not valid and will be unsupported from Home Assistant 2022.10

This change fix warning, but I'm a bit of confused because the old method is not explicitly used anywhere, so I changed the override only.

For now everything works smooth on my setup.

Fix: #777, #780.