### PR TITLE
 adapt LOOCK Dding Door Sensor 2 paired

### DIFF
--- a/custom_components/xiaomi_gateway3/core/device.py
+++ b/custom_components/xiaomi_gateway3/core/device.py
@@ -74,6 +74,8 @@ class XDevice:
 
         # TODO: assert mac
         self.type = type
+        if type == ZIGBEE:
+            model = model[:-19] if model[-19:-14] == "lumi." else model  # Remove the IEEE suffix from model after the LOOCK door sensor paired
         self.model = model
         self.did = did
         self.mac = mac


### PR DESCRIPTION
LOOCK  Dding Door Sensor 2  DDS-02, The model name is show model+‘lumi.’+IEEE after paired

"e70f96b3773a4c9283c6862dbafb6a99lumi.158d0001d38ade": ["LOOCK", "Dding Door Sensor 2", "DDS-02"],
"e70f96b3773a4c9283c6862dbafb6a99lumi.158d0001d98f2e": ["LOOCK", "Dding Door Sensor 2", "DDS-02"],
……

So simplifies to:
"e70f96b3773a4c9283c6862dbafb6a99": ["LOOCK", "Dding Door Sensor 2", "DDS-02"],

Try to pull request . If it passes, I will not need to modify it to use "xiaomi_gateway3.py" after each upgrade this component.

Thanks.

![loockdds02](https://user-images.githubusercontent.com/16587914/182806132-5642a53b-cc82-4bd0-99da-1a9318d3912e.jpg)

![2](https://user-images.githubusercontent.com/16587914/182805707-e42d9d98-27cc-417c-8b22-fb2222d2161a.jpg)

