### PR TITLE
revise ZIASZoneConv

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/zigbee.py
+++ b/custom_components/xiaomi_gateway3/core/converters/zigbee.py
@@ -214,7 +214,7 @@ class ZIASZoneConv(ZConverter):
 
     def decode(self, device: "XDevice", payload: dict, value: dict):
         try:
-            payload[self.attr] = value["value"][0] == 1
+            payload[self.attr] = (value["value"][0] & 1) > 0
         except Exception:
             pass
 


### PR DESCRIPTION
Adapt to more types of devices, such as Loock / HEIMAN /Tuya Door / occupancy / gas / smoke /water_leak  sensors.  


```
recv {'endpoint': 1, 'seq': 26, 'cluster': 'ias_zone', 'command_id': 0, 'command': 'enroll_response', 'value': status_change_notification(zone_status=<ZoneStatus.Restore_reports|Alarm_1: 33>, extended_status=<bitmap8.0: 0>, zone_id=0, delay=0)}

recv {'endpoint': 1, 'seq': 27, 'cluster': 'ias_zone', 'command_id': 0, 'command': 'enroll_response', 'value': status_change_notification(zone_status=<ZoneStatus.0: 0>, extended_status=<bitmap8.0: 0>, zone_id=0, delay=0)}

```