### PR TITLE
Add basic support for Xiaomi T700 Toothbrush

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1265,6 +1265,7 @@ DEVICES += [{
     982: ["Xiaomi", "Qingping Door Sensor", "CGH1"],
     1034: ["Xiaomi", "Mosquito Repellent", "WX08ZM"],
     1161: ["Xiaomi", "Toothbrush T500", "MES601"],
+    2054: ["Xiaomi", "Toothbrush T700", "MES604"],
     1433: ["Xiaomi", "Door Lock", "MJZNMS03LM"],
     1694: ["Aqara", "Door Lock N100 (Bluetooth)", "ZNMS16LM"],
     1695: ["Aqara", "Door Lock N200", "ZNMS17LM"],


### PR DESCRIPTION
Add basic support (battery and supply) for Xiaomi T700 Toothbrush - MES604 - k0918.toothbrush.t700