### PR TITLE
Add TTL for WX10ZM

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1525,6 +1525,7 @@ DEVICES += [{
             0: "auto", 1: "battery", 2: "usb"
         }, enabled=False)
     ],
+    "ttl": "1440m"
 }, {
     # urn:miot-spec-v2:device:light:0000A001:yeelink-nl2:1:0000C81D 米家智能光感夜灯
     4736: ["Xiaomi", "Mesh Night Light", "MJYD05YL"],


### PR DESCRIPTION
Adding a TTL of 1440 minutes (1 day) prevents the entities from becoming Unavailable, at which point the device couldn't be controlled anymore. https://github.com/AlexxIT/XiaomiGateway3/issues/804