### PR TITLE
Add support for Linptech motion sensor version 2

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1256,6 +1256,12 @@ DEVICES += [{
     "spec": [MiBeacon, BLEAction, Button1, Button2, ButtonBoth, BLEBattery],
     "ttl": "16m",  # battery every 5 min
 }, {
+    10987: ["Linptech", "Linptech Motion Sensor v2", "hs1bb"],
+    "spec": [
+        MiBeacon, BLEMotion, BLEIlluminance, BLEBattery,
+        Converter("idle_time", "sensor", enabled=False),
+    ],
+}, {
     # BLE devices can be supported witout spec. New spec will be added
     # "on the fly" when device sends them. But better to rewrite right spec for
     # each device

--- a/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
+++ b/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
@@ -348,6 +348,20 @@ class MiBeaconConv(Converter):
                 payload.update({'action': 'button_1_hold'})
             if value == 2:
                 payload.update({'action': 'button_2_hold'})
+          
+        elif eid == 0x4818:  # 18456
+            # Linptech motion sensor version 2
+            payload['idle_time'] = int.from_bytes(data, 'little')
+
+        elif eid == 0x4A08:  # 18952
+            # Linptech motion sensor version 2
+            value = struct.unpack('<f', data)[0]
+            payload.update({'motion': True, 'illuminance': value})
+
+        elif eid == 0x4C03:  # 19459
+            # Linptech motion sensor version 2
+            payload['battery'] = data[0]
+
 
 
 MiBeacon = MiBeaconConv('mibeacon')


### PR DESCRIPTION
Help solve issue https://github.com/AlexxIT/XiaomiGateway3/issues/816 and https://github.com/AlexxIT/XiaomiGateway3/issues/809
Users need to upgrade the firmware of Linptech motion sensor which makes the product name become Linptech motion sensor 2 (not motion sensor with firmware 2.0.0).