### PR TITLE
Add Tuya Temperature/Humidity Sensor IH-K009

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1035,6 +1035,7 @@ DEVICES += [{
     ],
 }, {
     "RH3052": ["Tuya", "TH sensor", "TT001ZAV20"],
+    "TS0201": ["Tuya", "TH sensor", "IH-K009"],
     "support": 3,
     "spec": [
         ZTemperatureConv("temperature", "sensor"),


### PR DESCRIPTION
Adds support for this cheap sensor https://www.zigbee2mqtt.io/devices/IH-K009.html

Works ok, though sensors become unavailable from time to time.
Is there a chance I can fix this by tweaking the config?

<img width="1244" alt="Screenshot 2022-10-28 at 23 34 15" src="https://user-images.githubusercontent.com/3177746/198727341-04364d16-c3a9-4df5-9ce2-27d0ec89acc8.png">
