### PR TITLE
Add Tuya Motion Sensor IH012-RT01

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1051,6 +1051,11 @@ DEVICES += [{
         ZBatteryConv("battery", "sensor", report="1h 12h 0"),
     ],
 }, {
+    "TS0202": ["Tuya", "Motion Sensor", "IH012-RT01"],
+    "spec": [
+        ZIASZoneConv("occupancy", "binary_sensor"),
+    ],
+}, {
     # very simple relays
     "01MINIZB": ["Sonoff", "Mini", "ZBMINI"],
     "SA-003-Zigbee": ["eWeLink", "Zigbee OnOff Controller", "SA-003-Zigbee"],


### PR DESCRIPTION
Adds support for https://www.zigbee2mqtt.io/devices/IH012-RT01.html

I basically copy-pasted RH3040 and cleaned-up things I wasn't sure about.
Works ok, though it becomes unavailable from time to time.
 
<img width="1027" alt="Screenshot 2022-10-28 at 23 56 33" src="https://user-images.githubusercontent.com/3177746/198730971-3b4a8eeb-0952-467a-ac0c-20d811863f10.png">
