### PR TITLE
Add support for Xiaomi Wireless Switch Bluetooth Version XMWXKG01LM

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1303,6 +1303,10 @@ DEVICES += [{
     "spec": [MiBeacon, BLEAction, Button, BLEBattery],
     "ttl": "6h" # battery every 6 hours
 }, {
+    9095: ["Xiaomi", "Xiaomi Wireless Switch Bluetooth Version", "XMWXKG01LM"],
+    "spec": [MiBeacon, BLEAction, Button, BLEBattery],
+    "ttl": "6h" # battery every 6 hours
+}, {
     # BLE devices can be supported witout spec. New spec will be added
     # "on the fly" when device sends them. But better to rewrite right spec for
     # each device

--- a/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
+++ b/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
@@ -341,22 +341,33 @@ class MiBeaconConv(Converter):
                     payload.update({'action': 'hold'})
                 if value == 15:
                     payload.update({'action': 'double'})
+            # wireless button Xiaomi Wireless Switch Bluetooth Version
+            elif device.model == 9095:
+                payload.update({'action': 'single'})
 
         elif eid == 0x4E0D:  # 19981
-            # wireless button XMWXKG01YL
             value = int.from_bytes(data, 'little')
-            if value == 1:
-                payload.update({'action': 'button_1_double'})
-            if value == 2:
-                payload.update({'action': 'button_2_double'})
+            # wireless button XMWXKG01YL
+            if device.model == 6473:
+                if value == 1:
+                    payload.update({'action': 'button_1_double'})
+                if value == 2:
+                    payload.update({'action': 'button_2_double'})\
+            # wireless button Xiaomi Wireless Switch Bluetooth Version
+            elif device.model == 9095:
+                payload.update({'action': 'double'})
 
         elif eid == 0x4E0E:  # 19982
-            # wireless button XMWXKG01YL
             value = int.from_bytes(data, 'little')
-            if value == 1:
-                payload.update({'action': 'button_1_hold'})
-            if value == 2:
-                payload.update({'action': 'button_2_hold'})
+            # wireless button XMWXKG01YL
+            if device.model == 6473:
+                if value == 1:
+                    payload.update({'action': 'button_1_hold'})
+                if value == 2:
+                    payload.update({'action': 'button_2_hold'})
+            # wireless button Xiaomi Wireless Switch Bluetooth Version
+            elif device.model == 9095:
+                payload.update({'action': 'hold'})
 
         elif eid == 0x4818:  # 18456
             # Linptech motion sensor version 2


### PR DESCRIPTION
info:
https://www.xiaomiyoupin.com/detail?gid=157151&spmref=YouPinPC.$Home$.list.0.83076497
https://www.notebookcheck.net/Xiaomi-Wireless-Switch-Bluetooth-Version-with-triple-controls-launches.669951.0.html

It seems that now channel 19980~19982 are used for wireless button.
