### PR TITLE
Support Xiaomi Smart Door Lock with Face Unlock(without X) 

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1207,6 +1207,16 @@ DEVICES += [{
         Converter("lock", "binary_sensor"),
     ],
 }, {
+    6017: ["Xiaomi", "Face Recognition Smart Door Lock", "XMZNMS09LM"],
+    "spec": [
+        MiBeacon,
+        Converter("action", "sensor"),
+        Converter("battery", "sensor"),
+        Converter("doorbell","sensor"),
+        Converter("contact", "binary_sensor"),
+        Converter("lock", "binary_sensor"),
+    ],
+},{
     6473: ["Xiaomi", "Wireless Button (Double)", "XMWXKG01YL"],
     "spec": [MiBeacon, BLEAction, Button1, Button2, ButtonBoth, BLEBattery],
     "ttl": "16m",  # battery every 5 min


### PR DESCRIPTION
Add the BLE Spec lock data parse and 6017 converter to support the Xiaomi Smart Door Lock with Face Unlock(without X) 
BLE code:6017, device model: XMZNMS09LM
[miot-spec](https://home.miot-spec.com/spec/lumi.lock.mcn002)