### PR TITLE
Add multiply to idle_time for IZQ

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1666,7 +1666,7 @@ DEVICES += [{
         BoolConv("occupancy", "binary_sensor", mi="2.p.1"),
         MathConv("no_one_determine_time", "number", mi="2.p.2", min=0, max=10000),
         MathConv("has_someone_duration", "sensor", mi="2.p.3"),
-        MathConv("idle_time", "sensor", mi="2.p.4"),
+        MathConv("idle_time", "sensor", mi="2.p.4", multiply=60), 
         MathConv("illuminance", "sensor", mi="2.p.5"),
         MathConv("distance", "sensor", mi="2.p.6"),
 


### PR DESCRIPTION
The unit of idle_time is seconds, and the unit reported by the sensor is minutes.


![ZQI](https://user-images.githubusercontent.com/16587914/209456208-0997b461-1c36-4c6a-8d5b-09ba9d617414.jpg)
