### PR TITLE
fix an error about the rssi type wrong conversion

### DIFF
--- a/custom_components/xiaomi_gateway3/core/gateway/gate_mgw2.py
+++ b/custom_components/xiaomi_gateway3/core/gateway/gate_mgw2.py
@@ -73,13 +73,12 @@ class GateMGW2(
                 rssi = await sh.read_file(
                     "/proc/net/wireless | grep wlan0 | awk '{print $4}' | cut -f1 -d."
                 )
-                if not rssi: rssi = 0
                 payload = self.device.decode(GATEWAY, {
                     "serial": serial.decode(),
                     "free_mem": int(free_mem),
                     "load_avg": load_avg.decode(),
                     "run_time": int(run_time),
-                    "rssi": int(rssi) + 100 if len(rssi) >=1 else 0
+                    "rssi": int(rssi) + 100 if rssi else 0
                 })
                 self.device.update(payload)
 


### PR DESCRIPTION
2022-12-23 19:12:45.616 WARNING (MainThread) [custom_components.xiaomi_gateway3.core.gateway] 192.168.1.10 | Can't update gateway stats
Traceback (most recent call last):
File "/config/custom_components/xiaomi_gateway3/core/gateway/gate_mgw2.py", line 82, in mgw2_update_stats
"rssi": int(rssi) + 100 if len(rssi) >=1 else 0
TypeError: object of type 'int' has no len()