### PR TITLE
Add support for Xiaomi Door Lock 1s XMZNMS08LM

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1289,6 +1289,16 @@ DEVICES += [{
     "spec": [MiBeacon, BLEAction, Button, BLEBattery],
     "ttl": "6h"  # battery every 6 hours
 }, {
+    3641: ["Xiaomi", "Door Lock 1S", "XMZNMS08LM"],
+    "spec": [
+        MiBeacon,
+        Converter("action", "sensor"),
+        Converter("battery", "sensor"),
+        Converter("doorbell", "sensor"),
+        Converter("contact", "binary_sensor"),
+    ],
+    "ttl": "3d"  # battery every 1? day
+}, {
     # BLE devices can be supported witout spec. New spec will be added
     # "on the fly" when device sends them. But better to rewrite right spec for
     # each device

--- a/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
+++ b/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
@@ -327,13 +327,27 @@ class MiBeaconConv(Converter):
             })
 
         elif eid == 0x0007:
-            # TODO: lock timestamp
-            if data[0] >= len(BLE_DOOR_ACTION):
+            action = data[0]
+            if action >= len(BLE_DOOR_ACTION):
                 return
+
+            timestamp = int.from_bytes(data[1:5], 'little')
+            timestamp = datetime.fromtimestamp(timestamp).isoformat()
+
+            if action == 0:
+                # 0 open, 1 closed
+                payload['contact'] = True
+            elif action == 1:
+                payload['contact'] = False
+            elif action == 3:
+                # 3 doorbell
+                payload['doorbell'] = timestamp
+
             payload.update({
                 'action': 'door',
-                'action_id': data[0],
-                'message': BLE_DOOR_ACTION[data[0]]
+                'action_id': action,
+                'message': BLE_DOOR_ACTION[action],
+                'timestamp': timestamp
             })
 
         elif eid == 0x0008:


### PR DESCRIPTION
Add Contant & Doorbell support
Relative logs:
```
2023-01-20 03:05:06,016 192.168.0.200 [MQTT] miio/report b'{"id":758644567,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":7,"edata":"01e204ca63"}],"frmCnt":128,"gwts":1674183904}}'
2023-01-20 03:05:06,017 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'contact': False, 'action': 'door', 'action_id': 1, 'message': 'Door is closed', 'timestamp': '2023-01-20T03:05:06'}
2023-01-20 03:05:06,087 192.168.0.200 [MQTT] miio/report_ack b'{"id":758644567,"result":"ok"}'
2023-01-20 03:05:10,608 192.168.0.200 [MQTT] miio/report b'{"id":754248568,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":7,"edata":"00e704ca63"}],"frmCnt":130,"gwts":1674183908}}'
2023-01-20 03:05:10,609 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'contact': True, 'action': 'door', 'action_id': 0, 'message': 'Door is open', 'timestamp': '2023-01-20T03:05:11'}
2023-01-20 03:05:10,687 192.168.0.200 [MQTT] miio/report_ack b'{"id":754248568,"result":"ok"}'
2023-01-20 03:05:12,637 192.168.0.200 [MQTT] miio/report b'{"id":2142354569,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":11,"edata":"3000000380e804ca63"}],"frmCnt":131,"gwts":1674183910}}'
2023-01-20 03:05:12,638 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'action': 'lock', 'action_id': 0, 'method_id': 3, 'message': 'Unlock outside the door', 'method': 'key', 'key_id': 0, 'error': None, 'timestamp': '2023-01-20T03:05:12'}
2023-01-20 03:05:12,707 192.168.0.200 [MQTT] miio/report_ack b'{"id":2142354569,"result":"ok"}'
2023-01-20 03:05:17,737 192.168.0.200 [MQTT] miio/report b'{"id":267590571,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":7,"edata":"03ee04ca63"}],"frmCnt":133,"gwts":1674183915}}'
2023-01-20 03:05:17,738 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'doorbell': '2023-01-20T03:05:18', 'action': 'door', 'action_id': 3, 'message': 'Knock on the door', 'timestamp': '2023-01-20T03:05:18'}
2023-01-20 03:05:17,806 192.168.0.200 [MQTT] miio/report_ack b'{"id":267590571,"result":"ok"}'
2023-01-20 03:05:59,527 192.168.0.200 [MQTT] miio/report b'{"id":1013800579,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":7,"edata":"011705ca63"}],"frmCnt":135,"gwts":1674183957}}'
2023-01-20 03:05:59,528 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'contact': False, 'action': 'door', 'action_id': 1, 'message': 'Door is closed', 'timestamp': '2023-01-20T03:05:59'}
2023-01-20 03:05:59,607 192.168.0.200 [MQTT] miio/report_ack b'{"id":1013800579,"result":"ok"}'
2023-01-20 03:06:02,588 192.168.0.200 [MQTT] miio/report b'{"id":287583580,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":11,"edata":"a1000000001a05ca63"}],"frmCnt":137,"gwts":1674183960}}'
2023-01-20 03:06:02,589 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'action': 'lock', 'action_id': 1, 'method_id': 10, 'message': 'Lock', 'method': 'manual', 'key_id': 0, 'error': None, 'timestamp': '2023-01-20T03:06:02'}
2023-01-20 03:06:02,666 192.168.0.200 [MQTT] miio/report_ack b'{"id":287583580,"result":"ok"}'
2023-01-20 03:06:06,156 192.168.0.200 [MQTT] miio/report b'{"id":797163582,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":7,"edata":"001f05ca63"}],"frmCnt":139,"gwts":1674183964}}'
2023-01-20 03:06:06,158 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'contact': True, 'action': 'door', 'action_id': 0, 'message': 'Door is open', 'timestamp': '2023-01-20T03:06:07'}
2023-01-20 03:06:06,228 192.168.0.200 [MQTT] miio/report_ack b'{"id":797163582,"result":"ok"}'
2023-01-20 03:06:08,197 192.168.0.200 [MQTT] miio/report b'{"id":1456733583,"method":"_async.ble_event","params":{"dev":{"did":"1026145794","mac":"D6:65:24:XX:XX:XX","pdid":3641},"evt":[{"eid":11,"edata":"30000003802005ca63"}],"frmCnt":140,"gwts":1674183966}}'
2023-01-20 03:06:08,197 192.168.0.200 [BLEE] d66524ce920b (3641) recv {'action': 'lock', 'action_id': 0, 'method_id': 3, 'message': 'Unlock outside the door', 'method': 'key', 'key_id': 0, 'error': None, 'timestamp': '2023-01-20T03:06:08'}
```