### PR TITLE
Add battery to MJWSD05MMC and LYWSD02MMC

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1196,13 +1196,15 @@ DEVICES += [{
         Converter("battery", "sensor", enabled=None),  # no in new firmwares
     ],
 }, {
+    # https://home.miot-spec.com/spec/miaomiaoce.sensor_ht.t8
     9538: ["Xiaomi", "TH Clock Pro", "LYWSD02MMC"],
     # https://home.miot-spec.com/spec/miaomiaoce.sensor_ht.t9
-    10290: ["Xiaomi", "TH Sensor 3", "MJWSDO5MMC"],
+    10290: ["Xiaomi", "TH Sensor 3", "MJWSD05MMC"],
     "spec": [
         MiBeacon, BLETemperature, BLEHumidity,
         MathConv("temperature", mi="3.p.1001", min=-30, max=100, round=1),
         MathConv("humidity", mi="3.p.1002", min=0, max=100, round=0),
+        Converter("battery", "sensor", mi="2.p.1003", enabled=None),
     ]
 }, {
     2038: ["Xiaomi", "Night Light 2", "MJYD02YL-A"],  # 15,4103,4106,4119,4120


### PR DESCRIPTION
Hello, I found these two devices are no battery in HA, 
so try added this line:

```python
Converter("battery", "sensor", mi="2.p.1003", enabled=None),
```

battery would be unknown first, and after a long time, it got value.

---

waited for a day and got these logs:

- logs for Xiaomi TH Clock Pro (LYWSD02MMC) (9538)

```
2023-01-28 00:00:00,925 10.1.0.104 [MQTT] miio/report b'{"id":1198835093,"method":"properties_changed","params":[{"did":"blt.3.1chlqfvj05c00","siid":2,"piid":1003,"value":100,"tid":214}],"type":6}'
2023-01-28 12:00:02,267 10.1.0.104 [MQTT] miio/report b'{"id":919575028,"method":"properties_changed","params":[{"did":"blt.3.1chlqfvj05c00","siid":2,"piid":1003,"value":100,"tid":209}],"type":6}'
```

- logs for Xiaomi TH Sensor 3 (MJWSD05MMC) (10290)

```
2023-01-28 00:00:06,015 10.1.0.104 [MQTT] miio/report b'{"id":1326838096,"method":"properties_changed","params":[{"did":"blt.3.1cj5tsquoeg00","siid":2,"piid":1003,"value":100,"tid":149}],"type":6}'
2023-01-28 12:00:05,835 10.1.0.104 [MQTT] miio/report b'{"id":767337031,"method":"properties_changed","params":[{"did":"blt.3.1cj5tsquoeg00","siid":2,"piid":1003,"value":100,"tid":59}],"type":6}'
```

---

and, is `MJWSD05MMC` not `MJWSDO5MMC`.