### PR TITLE
add unit for distance with "m"

### DIFF
--- a/custom_components/xiaomi_gateway3/sensor.py
+++ b/custom_components/xiaomi_gateway3/sensor.py
@@ -38,18 +38,18 @@ UNITS = {
     "humidity": PERCENTAGE,
     # zb light and motion and ble flower - lux
     "illuminance": LIGHT_LUX,
-    "power": POWER_WATT,
-    "voltage": ELECTRIC_POTENTIAL_VOLT,
-    "current": ELECTRIC_CURRENT_AMPERE,
-    "pressure": PRESSURE_HPA,
-    "temperature": TEMP_CELSIUS,
-    "energy": ENERGY_KILO_WATT_HOUR,
-    "chip_temperature": TEMP_CELSIUS,
+    "power": POWER_WATT, # Deprecated: please use UnitOfPower.WATT.
+    "voltage": ELECTRIC_POTENTIAL_VOLT, # Deprecated: please use UnitOfElectricPotential.VOLT.
+    "current": ELECTRIC_CURRENT_AMPERE, # Deprecated: please use UnitOfElectricCurrent.AMPERE.
+    "pressure": PRESSURE_HPA,  # Deprecated: please use UnitOfPressure.HPA
+    "temperature": TEMP_CELSIUS, # Deprecated: please use UnitOfTemperature.CELSIUS
+    "energy": ENERGY_KILO_WATT_HOUR, # Deprecated: please use UnitOfEnergy.KILO_WATT_HOUR.
+    "chip_temperature": TEMP_CELSIUS, # Deprecated: please use UnitOfTemperature.CELSIUS
     "conductivity": CONDUCTIVITY,
     "gas_density": "% LEL",
-    "idle_time": TIME_SECONDS,
+    "idle_time": TIME_SECONDS, # Deprecated: please use UnitOfTime.SECONDS.
     "linkquality": "lqi",
-    "max_power": POWER_WATT,
+    "max_power": POWER_WATT, # Deprecated: please use UnitOfPower.WATT.
     "moisture": PERCENTAGE,
     "msg_received": "msg",
     "msg_missed": "msg",
@@ -58,7 +58,8 @@ UNITS = {
     "rssi": SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     "smoke_density": "% obs/ft",
     "supply": PERCENTAGE,
-    "tvoc": CONCENTRATION_PARTS_PER_BILLION,
+    "tvoc": CONCENTRATION_PARTS_PER_BILLION, 
+    "distance": LENGTH_METERS, # Deprecated: please use UnitOfLength.METERS.
     # "link_quality": "lqi",
     # "rssi": "dBm",
     # "msg_received": "msg",


### PR DESCRIPTION
Home Assistant 2023.2.1
Xiaomi Gateway 3 version | 3.1.0


Logger: homeassistant.components.sensor
Source: components/sensor/init.py:674
Integration: 传感器 ([documentation](https://www.home-assistant.io/integrations/sensor), [issues](https://github.com/home-assistant/home-assistant/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+sensor%22))
First occurred: 20:37:46 (1 occurrences)
Last logged: 20:37:46

Entity sensor.ccb5d1d4a593_distance (<class 'custom_components.xiaomi_gateway3.sensor.XiaomiSensor'>) is using native unit of measurement 'None' which is not a valid unit for the device class ('distance') it is using; expected one of ['ft', 'm', 'km', 'mm', 'in', 'mi', 'yd', 'cm']; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.

```python
{
    10356: ["ZiQing", "IZQ Presence Sensor Lite", "IZQ-24"],
    "spec": [
        BoolConv("occupancy", "binary_sensor", mi="2.p.1"),
        MathConv("no_one_determine_time", "number", mi="2.p.2", min=0, max=10000),
        MathConv("has_someone_duration", "sensor", mi="2.p.3"),
        MathConv("idle_time", "sensor", mi="2.p.4", multiply=60),
        MathConv("illuminance", "sensor", mi="2.p.5"),
        MathConv("distance", "sensor", mi="2.p.6"),

        Converter("led", "switch", mi="3.p.1", enabled=True),
        MathConv("detect_range", "number", mi="3.p.2", min=0, max=8),
        Converter("pir", "switch", mi="3.p.3", enabled=True),

        MapConv("occupancy_status", "sensor", mi="2.p.1", map={
            0: "NoOne", 1: "EnterIn", 2: "SmallMove", 3: "MicroMove", 4: "Approaching",
            5: "MoveAway"
        }),
    ],
}
```
MathConv("distance", "sensor", mi="2.p.6"),  the unit of this distance is "m".

By the way, add the remarks from homeassistant.const for possible future,

