### PR TITLE
Fix false msd_missed

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/stats.py
+++ b/custom_components/xiaomi_gateway3/core/converters/stats.py
@@ -158,7 +158,7 @@ class ZigbeeStatsConverter(Converter):
                     )
                     # sometimes device repeat message, skip this situation:
                     # 0xF6 > 0xF7 > 0xF8 > 0xF7 > 0xF8 > 0xF9
-                    if 0 < miss < 254:
+                    if 0 < miss < 240:
                         device.extra["msg_missed"] += miss
 
                 device.extra["last_seq1"] = new_seq1


### PR DESCRIPTION
Some zigbee devices can send more than two packets simultaneously. Hope new value can help to reduce the high number of false msg_missed packets.