### PR TITLE
Add support for Linptech Door/Window Sensor (MS1BB)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1308,6 +1308,14 @@ DEVICES += [{
     ],
     "ttl": "3d",  # battery every 1 day
 }, {
+    6281: ["Linptech", "Door/Window Sensor", "MS1BB"],
+    "spec": [
+        MiBeacon, BLEContact, BLEBattery,
+        MapConv("contact", mi="2.p.1004", map={1: True, 2: False}),
+        Converter("battery", mi="3.p.1003"),
+    ],
+    "ttl": "60m",
+}, {
     2455: ["Honeywell", "Smoke Alarm", "JTYJ-GD-03MI"],
     "spec": [MiBeacon, BLEAction, BLESmoke, BLEBattery],
     "ttl": "60m",  # battery every 4:30 min


### PR DESCRIPTION
https://home.miot-spec.com/spec/linp.magnet.m1
https://www.linptech.com/141917968.html

Added `contact` and `battery`.

This device also has a button, but i don't know how to support it.

Here is the logs
```
# close
2023-03-11 18:31:00,785 10.1.0.104 [MQTT] miio/report b'{"id":1950467561,"method":"event_occured","params":{"did":"blt.3.1cv7i8ruoe000","siid":2,"eiid":1018,"tid":89,"arguments":[{"piid":1004,"value":2}]},"type":6}'
2023-03-11 18:31:02,314 10.1.0.104 [MQTT] miio/report b'{"id":1283120562,"method":"properties_changed","params":[{"did":"blt.3.1cv7i8ruoe000","siid":2,"piid":1004,"value":2,"tid":90}],"type":6}'
# open
2023-03-11 18:31:04,864 10.1.0.104 [MQTT] miio/report b'{"id":477049564,"method":"event_occured","params":{"did":"blt.3.1cv7i8ruoe000","siid":2,"eiid":1018,"tid":91,"arguments":[{"piid":1004,"value":1}]},"type":6}'
2023-03-11 18:31:06,905 10.1.0.104 [MQTT] miio/report b'{"id":1768746566,"method":"properties_changed","params":[{"did":"blt.3.1cv7i8ruoe000","siid":2,"piid":1004,"value":1,"tid":92}],"type":6}'
# click
2023-03-11 18:31:09,455 10.1.0.104 [MQTT] miio/report b'{"id":801303567,"method":"event_occured","params":{"did":"blt.3.1cv7i8ruoe000","siid":2,"eiid":1019,"tid":93,"arguments":[{"piid":1004,"value":1}]},"type":6}'
# close
2023-03-11 18:31:14,554 10.1.0.104 [MQTT] miio/report b'{"id":1853666569,"method":"event_occured","params":{"did":"blt.3.1cv7i8ruoe000","siid":2,"eiid":1018,"tid":94,"arguments":[{"piid":1004,"value":2}]},"type":6}'
2023-03-11 18:31:17,104 10.1.0.104 [MQTT] miio/report b'{"id":1673478570,"method":"properties_changed","params":[{"did":"blt.3.1cv7i8ruoe000","siid":2,"piid":1004,"value":2,"tid":95}],"type":6}'
# click
2023-03-11 18:31:19,635 10.1.0.104 [MQTT] miio/report b'{"id":495990571,"method":"event_occured","params":{"did":"blt.3.1cv7i8ruoe000","siid":2,"eiid":1019,"tid":96,"arguments":[{"piid":1004,"value":1}]},"type":6}'
# open
2023-03-11 18:31:23,714 10.1.0.104 [MQTT] miio/report b'{"id":64878575,"method":"event_occured","params":{"did":"blt.3.1cv7i8ruoe000","siid":2,"eiid":1018,"tid":97,"arguments":[{"piid":1004,"value":1}]},"type":6}'
2023-03-11 18:31:25,244 10.1.0.104 [MQTT] miio/report b'{"id":1205320579,"method":"properties_changed","params":[{"did":"blt.3.1cv7i8ruoe000","siid":2,"piid":1004,"value":1,"tid":98}],"type":6}'
```