### PR TITLE
Add support to 6 unknown brand mesh wall switches (id starting with "babai.switch.2")

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,11 +353,12 @@ Total devices: 54
 |Unknown|Mesh Switch|[dwdz.switch.sw0a01](https://home.miot-spec.com/s/4252)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a01](https://home.miot-spec.com/s/2007)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a02](https://home.miot-spec.com/s/3169)|switch||
-|Unknown|Mesh Double Wall Switch (with N)|[babai.switch.202m"](https://home.miot-spec.com/s/6528)|channel_1, channel_2, wireless_1, wireless_2||
-|Unknown|Mesh Triple Wall Switch (with N)|[babai.switch.203m"](https://home.miot-spec.com/s/6529)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
-|Unknown|Mesh Single Wall Switch (no N)|[babai.switch.201ml"](https://home.miot-spec.com/s/7219)|channel, wireless||
-|Unknown|Mesh Double Wall Switch (no N)|[babai.switch.202ml"](https://home.miot-spec.com/s/7220)|channel_1, channel_2, wireless_1, wireless_2||
-|Unknown|Mesh Triple Wall Switch (no N)|[babai.switch.203ml"](https://home.miot-spec.com/s/7221)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
+|Unknown|Mesh Single Wall Switch (with N) 2021|[babai.switch.201m"](https://home.miot-spec.com/s/6514)|channel, wireless||
+|Unknown|Mesh Double Wall Switch (with N) 2021|[babai.switch.202m"](https://home.miot-spec.com/s/6528)|channel_1, channel_2, wireless_1, wireless_2||
+|Unknown|Mesh Triple Wall Switch (with N) 2021|[babai.switch.203m"](https://home.miot-spec.com/s/6529)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
+|Unknown|Mesh Single Wall Switch (no N) 2021|[babai.switch.201ml"](https://home.miot-spec.com/s/7219)|channel, wireless||
+|Unknown|Mesh Double Wall Switch (no N) 2021|[babai.switch.202ml"](https://home.miot-spec.com/s/7220)|channel_1, channel_2, wireless_1, wireless_2||
+|Unknown|Mesh Triple Wall Switch (no N) 2021|[babai.switch.203ml"](https://home.miot-spec.com/s/7221)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
 |Xiaomi|Electrical Outlet|[ZNCZ01ZM](https://home.miot-spec.com/s/3083)|outlet, power, led, power_protect, power_value||
 |Xiaomi|Mesh Bulb|[MJDP09YL](https://home.miot-spec.com/s/1771)|light, flex_switch, power_on_state|4|
 |Xiaomi|Mesh Double Wall Switch|[DHKG02ZM](https://home.miot-spec.com/s/1946)|channel_1, channel_2, led, wireless_1, wireless_2, action||

--- a/README.md
+++ b/README.md
@@ -353,12 +353,12 @@ Total devices: 54
 |Unknown|Mesh Switch|[dwdz.switch.sw0a01](https://home.miot-spec.com/s/4252)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a01](https://home.miot-spec.com/s/2007)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a02](https://home.miot-spec.com/s/3169)|switch||
-|Unknown|Mesh Single Wall Switch (with N) 2021|[babai.switch.201m"](https://home.miot-spec.com/s/6514)|channel, wireless||
-|Unknown|Mesh Double Wall Switch (with N) 2021|[babai.switch.202m"](https://home.miot-spec.com/s/6528)|channel_1, channel_2, wireless_1, wireless_2||
-|Unknown|Mesh Triple Wall Switch (with N) 2021|[babai.switch.203m"](https://home.miot-spec.com/s/6529)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
-|Unknown|Mesh Single Wall Switch (no N) 2021|[babai.switch.201ml"](https://home.miot-spec.com/s/7219)|channel, wireless||
-|Unknown|Mesh Double Wall Switch (no N) 2021|[babai.switch.202ml"](https://home.miot-spec.com/s/7220)|channel_1, channel_2, wireless_1, wireless_2||
-|Unknown|Mesh Triple Wall Switch (no N) 2021|[babai.switch.203ml"](https://home.miot-spec.com/s/7221)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
+|Unknown|Mesh Single Wall Switch (with N)|[babai.switch.201m"](https://home.miot-spec.com/s/6514)|channel, wireless||
+|Unknown|Mesh Double Wall Switch (with N)|[babai.switch.202m"](https://home.miot-spec.com/s/6528)|channel_1, channel_2, wireless_1, wireless_2||
+|Unknown|Mesh Triple Wall Switch (with N)|[babai.switch.203m"](https://home.miot-spec.com/s/6529)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
+|Unknown|Mesh Single Wall Switch (no N)|[babai.switch.201ml"](https://home.miot-spec.com/s/7219)|channel, wireless||
+|Unknown|Mesh Double Wall Switch (no N)|[babai.switch.202ml"](https://home.miot-spec.com/s/7220)|channel_1, channel_2, wireless_1, wireless_2||
+|Unknown|Mesh Triple Wall Switch (no N)|[babai.switch.203ml"](https://home.miot-spec.com/s/7221)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
 |Xiaomi|Electrical Outlet|[ZNCZ01ZM](https://home.miot-spec.com/s/3083)|outlet, power, led, power_protect, power_value||
 |Xiaomi|Mesh Bulb|[MJDP09YL](https://home.miot-spec.com/s/1771)|light, flex_switch, power_on_state|4|
 |Xiaomi|Mesh Double Wall Switch|[DHKG02ZM](https://home.miot-spec.com/s/1946)|channel_1, channel_2, led, wireless_1, wireless_2, action||

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Total devices: 42
 
 ### Supported Xiaomi Mesh
 
-Total devices: 49
+Total devices: 54
 
 |Brand|Name|Model|Entities|S|
 |---|---|---|---|---|
@@ -353,6 +353,11 @@ Total devices: 49
 |Unknown|Mesh Switch|[dwdz.switch.sw0a01](https://home.miot-spec.com/s/4252)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a01](https://home.miot-spec.com/s/2007)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a02](https://home.miot-spec.com/s/3169)|switch||
+|Unknown|Mesh Double Wall Switch (with N)|[babai.switch.202m"](https://home.miot-spec.com/s/6528)|channel_1, channel_2, wireless_1, wireless_2||
+|Unknown|Mesh Triple Wall Switch (with N)|[babai.switch.203m"](https://home.miot-spec.com/s/6529)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
+|Unknown|Mesh Single Wall Switch (no N)|[babai.switch.201ml"](https://home.miot-spec.com/s/7219)|channel, wireless||
+|Unknown|Mesh Double Wall Switch (no N)|[babai.switch.202ml"](https://home.miot-spec.com/s/7220)|channel_1, channel_2, wireless_1, wireless_2||
+|Unknown|Mesh Triple Wall Switch (no N)|[babai.switch.203ml"](https://home.miot-spec.com/s/7221)|channel_1, channel_2, channel_3, wireless_1, wireless_2, wireless_3||
 |Xiaomi|Electrical Outlet|[ZNCZ01ZM](https://home.miot-spec.com/s/3083)|outlet, power, led, power_protect, power_value||
 |Xiaomi|Mesh Bulb|[MJDP09YL](https://home.miot-spec.com/s/1771)|light, flex_switch, power_on_state|4|
 |Xiaomi|Mesh Double Wall Switch|[DHKG02ZM](https://home.miot-spec.com/s/1946)|channel_1, channel_2, led, wireless_1, wireless_2, action||

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1852,6 +1852,16 @@ DEVICES += [{
     ],
 }, {
     # A third party module widely used in small brand wall switches
+    # https://home.miot-spec.com/s/6514
+    6514: ["Unknown", "Mesh Single Wall Switch (with N)", "babai.switch.201m"],
+    "spec": [
+        Converter("channel", "switch", mi="2.p.1"),
+
+        # Either Default/Wireless or Default/Atom, depending on hardware
+        BoolConv("wireless", "switch", mi="2.p.2", enabled=False),
+    ]
+}, {
+    # A third party module widely used in small brand wall switches
     # https://home.miot-spec.com/s/6528
     6528: ["Unknown", "Mesh Double Wall Switch (with N)", "babai.switch.202m"],
     "spec": [

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1851,6 +1851,68 @@ DEVICES += [{
         ColorTempKelvin("color_temp", mi="2.p.3", parent="light"),
     ],
 }, {
+    # A third party module widely used in small brand wall switches
+    # https://home.miot-spec.com/s/6528
+    6528: ["Unknown", "Mesh Double Wall Switch (with N)", "babai.switch.202m"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+
+        # Either Default/Wireless or Default/Atom, depending on hardware
+        BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
+        BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
+    ]
+}, {
+    # A third party module widely used in small brand wall switches
+    # https://home.miot-spec.com/s/6529
+    6529: ["Unknown", "Mesh Triple Wall Switch (with N)", "babai.switch.203m"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+        Converter("channel_3", "switch", mi="4.p.1"),
+
+        # Either Default/Wireless or Default/Atom, depending on hardware
+        BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
+        BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
+        BoolConv("wireless_3", "switch", mi="4.p.2", enabled=False),
+    ]
+}, {
+    # A third party module widely used in small brand wall switches
+    # https://home.miot-spec.com/s/7219
+    7219: ["Unknown", "Mesh Single Wall Switch (no N)", "babai.switch.201ml"],
+    "spec":[
+        Converter("channel", "switch", mi="2.p.1"),
+
+        # Either Default/Wireless or Default/Atom, depending on hardware
+        BoolConv("wireless", "switch", mi="2.p.2", enabled=False),
+    ]
+}, {
+    # A third party module widely used in small brand wall switches
+    # https://home.miot-spec.com/s/7220
+    7220: ["Unknown", "Mesh Double Wall Switch (no N)", "babai.switch.202ml"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+
+        # Either Default/Wireless or Default/Atom, depending on hardware
+        BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
+        BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
+    ]
+}, {
+    # A third party module widely used in small brand wall switches
+    # https://home.miot-spec.com/s/7221
+    7221: ["Unknown", "Mesh Triple Wall Switch (no N)", "babai.switch.203ml"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+        Converter("channel_3", "switch", mi="4.p.1"),
+
+        # Either Default/Wireless or Default/Atom, depending on hardware
+        BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
+        BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
+        BoolConv("wireless_3", "switch", mi="4.p.2", enabled=False),
+    ]
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool


### PR DESCRIPTION
Add basic supports for following devices:
1. Single (with N)
2. Double (with N)
3. Triple (with N)
4. Single (No N)
5. Double (No N)
6. Triple (No N)
Tested devices: 2, 4, 6

Remark: Currently only support 1. on/off and 2. option switching to wireless, because the tested devices coincidentally did not support all features mentioned in miot-spec.org such as power on state and led indicator control