### PR TITLE
Fix Xiaominumber deprecated method override warning

### DIFF
--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -35,43 +35,16 @@ UNITS = {
 
 # noinspection PyAbstractClass
 class XiaomiNumber(XEntity, NumberEntity):
-<<<<<<< HEAD
-    # Avoid assignment and override of deprecated attributes and methods (starting from core 2022.8)
+    # Avoid assignment and override of deprecated attributes and methods (starting from HA core 2022.8)
     # while ensuring backwards compatibility
     # Addressing: https://github.com/AlexxIT/XiaomiGateway3/issues/984#issue-1586983959
     #             https://github.com/AlexxIT/XiaomiGateway3/pull/789#issuecomment-1202188504
-    # Fix suggestion: https://community.home-assistant.io/t/depricated-numberentity-features/440282/2
-=======
-    _attr_value: float = None
-
-    def __init__(self, gateway: "XGateway", device: XDevice, conv: Converter):
-        super().__init__(gateway, device, conv)
-
-        if self.attr in UNITS:
-            self._attr_native_unit_of_measurement = UNITS[self.attr]
-
-        if hasattr(conv, "min"):
-            self._attr_min_value = conv.min
-        if hasattr(conv, "max"):
-            self._attr_max_value = conv.max
-
-    @callback
-    def async_set_state(self, data: dict):
-        if self.attr in data:
-            self._attr_value = data[self.attr]
-
-    @callback
-    def async_restore_last_state(self, state: float, attrs: dict):
-        self._attr_value = state
-
-    async def async_update(self):
-        await self.device_read(self.subscribed_attrs)
-
-    # backward compatibility fix
->>>>>>> cf192804062149d4fadc0b02b3c0813d77346c47
+    # Reference: https://community.home-assistant.io/t/depricated-numberentity-features/440282/2
     if (MAJOR_VERSION, MINOR_VERSION) >= (2022, 8):
         def __init__(self, gateway: "XGateway", device: XDevice, conv: Converter):
             super().__init__(gateway, device, conv)
+            if self.attr in UNITS:
+                self._attr_native_unit_of_measurement = UNITS[self.attr]
             if hasattr(conv, "min"):
                 self._attr_native_min_value = conv.min
             if hasattr(conv, "max"):
@@ -94,10 +67,14 @@ class XiaomiNumber(XEntity, NumberEntity):
     else: # (MAJOR_VERSION, MINOR_VERSION) < (2022, 8):
         def __init__(self, gateway: "XGateway", device: XDevice, conv: Converter):
             super().__init__(gateway, device, conv)
+            # Not sure if the following codes will break, thus left commented
+            # if self.attr in UNITS:
+            #     self._attr_unit_of_measurement = UNITS[self.attr]
             if hasattr(conv, "min"):
                 self._attr_min_value = conv.min
             if hasattr(conv, "max"):
                 self._attr_max_value = conv.max
+                
 
         async def async_set_value(self, value: float) -> None:
             await self.device_send({self.attr: value})

--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -24,8 +24,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 # noinspection PyAbstractClass
 class XiaomiNumber(XEntity, NumberEntity):
-    # Remove warning
-    # https://community.home-assistant.io/t/depricated-numberentity-features/440282/2
+    # Avoid assignment and override of deprecated attributes and methods (starting from core 2022.8)
+    # while ensuring backwards compatibility
+    # Addressing: https://github.com/AlexxIT/XiaomiGateway3/issues/984#issue-1586983959
+    #             https://github.com/AlexxIT/XiaomiGateway3/pull/789#issuecomment-1202188504
+    # Fix suggestion: https://community.home-assistant.io/t/depricated-numberentity-features/440282/2
     if (MAJOR_VERSION, MINOR_VERSION) >= (2022, 8):
         def __init__(self, gateway: "XGateway", device: XDevice, conv: Converter):
             super().__init__(gateway, device, conv)
@@ -48,8 +51,6 @@ class XiaomiNumber(XEntity, NumberEntity):
         async def async_update(self):
             await self.device_read(self.subscribed_attrs)
 
-    
-    # Satisfy codebase of older core 
     else: # (MAJOR_VERSION, MINOR_VERSION) < (2022, 8):
         def __init__(self, gateway: "XGateway", device: XDevice, conv: Converter):
             super().__init__(gateway, device, conv)


### PR DESCRIPTION
Addressing:
https://github.com/AlexxIT/XiaomiGateway3/issues/984#issue-1586983959 
and
https://github.com/AlexxIT/XiaomiGateway3/pull/789#issuecomment-1202188504

Change:
All deprecated 'NumberEntity' methods and attributes existing in 'XiaomiNumber' were overwritten with their respective successors.

References:
https://github.com/home-assistant/core/blob/dev/homeassistant/components/number/__init__.py
https://community.home-assistant.io/t/depricated-numberentity-features/440282

Tested on HA core 2023.3.6

