### PR TITLE
Add Unknown brand BLE mesh smart plug (giot.plug.v3shsm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Total devices: 50
 |Unknown|Mesh Switch|[dwdz.switch.sw0a01](https://home.miot-spec.com/s/4252)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a01](https://home.miot-spec.com/s/2007)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a02](https://home.miot-spec.com/s/3169)|switch||
-|Unknown|Mesh Smart Plug V3|[giot.plug.v3shsm](https://home.miot-spec.com/s/giot.plug.v3shsm)|plug, mode power_on_state, jog_mode_default_state, jog_duration, led ||
+|Unknown|Mesh Smart Plug V3|[giot.plug.v3shsm](https://home.miot-spec.com/s/giot.plug.v3shsm)|plug, inching_mode, power_on_state, inching_switch_default_state, inching_time, led ||
 |Xiaomi|Electrical Outlet|[ZNCZ01ZM](https://home.miot-spec.com/s/3083)|outlet, power, led, power_protect, power_value||
 |Xiaomi|Mesh Bulb|[MJDP09YL](https://home.miot-spec.com/s/1771)|light, flex_switch, power_on_state|4|
 |Xiaomi|Mesh Double Wall Switch|[DHKG02ZM](https://home.miot-spec.com/s/1946)|channel_1, channel_2, led, wireless_1, wireless_2, action||

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Total devices: 42
 
 ### Supported Xiaomi Mesh
 
-Total devices: 49
+Total devices: 50
 
 |Brand|Name|Model|Entities|S|
 |---|---|---|---|---|
@@ -353,6 +353,7 @@ Total devices: 49
 |Unknown|Mesh Switch|[dwdz.switch.sw0a01](https://home.miot-spec.com/s/4252)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a01](https://home.miot-spec.com/s/2007)|switch||
 |Unknown|Mesh Switch Controller|[lemesh.switch.sw0a02](https://home.miot-spec.com/s/3169)|switch||
+|Unknown|Mesh Smart Plug V3|[giot.plug.v3shsm](https://home.miot-spec.com/s/giot.plug.v3shsm)|plug, mode power_on_state, jog_mode_default_state, jog_duration, led ||
 |Xiaomi|Electrical Outlet|[ZNCZ01ZM](https://home.miot-spec.com/s/3083)|outlet, power, led, power_protect, power_value||
 |Xiaomi|Mesh Bulb|[MJDP09YL](https://home.miot-spec.com/s/1771)|light, flex_switch, power_on_state|4|
 |Xiaomi|Mesh Double Wall Switch|[DHKG02ZM](https://home.miot-spec.com/s/1946)|channel_1, channel_2, led, wireless_1, wireless_2, action||

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1867,18 +1867,18 @@ DEVICES += [{
     # https://home.miot-spec.com/s/giot.plug.v3shsm
     10920: ["Unknown", "Mesh Smart Plug V3", "giot.plug.v3shsm"],
     "spec": [
-        Converter("plug", "plug", mi="2.p.1"),
-        MapConv("mode","select", mi="2.p.2", map={0:"switch", 1:"jog"}),
+        Converter("plug", "switch", mi="2.p.1"),
+        BoolConv("inching_mode","switch", mi="2.p.2"),
         MapConv("power_on_state", "select", mi="2.p.3", map={0:"off",1:"on",2:"same_as_before"}),
 
-        # Jog mode
-        MapConv("jog_mode_default_state", "select", mi="3.p.1", map={False:"normally_closed",True:"normally_open"}),
-        MathConv("jog_duration", "number", mi="3.p.2",multiply=0.5, min=1, max=7199,round=1),
+        # Inching mode
+        MapConv("inching_switch_default_state", "select", mi="3.p.1", map={False:"normally_off",True:"normally_on"}),
+        MathConv("inching_time", "number", mi="3.p.2",multiply=0.5, min=1, max=7199,round=1),
 
         # LED
         MapConv("led", "select", mi="4.p.1", map={
-            0: "on_when_switch_closed", 
-            1: "on_when_switch_open", 
+            0: "follow_switch", 
+            1: "opposite_to_switch", 
             2: "normally_off", 
             3: "normally_on"
         })

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1851,6 +1851,26 @@ DEVICES += [{
         ColorTempKelvin("color_temp", mi="2.p.3", parent="light"),
     ],
 }, {
+    # https://home.miot-spec.com/s/giot.plug.v3shsm
+    10920: ["Unknown", "Mesh Smart Plug V3", "giot.plug.v3shsm"],
+    "spec": [
+        Converter("plug", "plug", mi="2.p.1"),
+        MapConv("mode","select", mi="2.p.2", map={0:"switch", 1:"jog"}),
+        MapConv("power_on_state", "select", mi="2.p.3", map={0:"off",1:"on",2:"same_as_before"}),
+
+        # Jog mode
+        MapConv("jog_mode_default_state", "select", mi="3.p.1", map={False:"normally_closed",True:"normally_open"}),
+        MathConv("jog_duration", "number", mi="3.p.2",multiply=0.5, min=1, max=7199,round=1),
+
+        # LED
+        MapConv("led", "select", mi="4.p.1", map={
+            0: "on_when_switch_closed", 
+            1: "on_when_switch_open", 
+            2: "normally_off", 
+            3: "normally_on"
+        })
+    ]
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool


### PR DESCRIPTION
According to spec: [giot.plug.v3shsm](https://home.miot-spec.com/s/giot.plug.v3shsm)
Tested on: HA core 2023.3

Remark: One of the attributes, "inching_time", behave correctly if class 'XiaomiNumber' deprecation issue is fixed (Pull request: https://github.com/AlexxIT/XiaomiGateway3/pull/1020)