### PR TITLE
Add Linptech Mesh Triple Wall Switch (no L)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1934,7 +1934,7 @@ DEVICES += [{
         Converter("channel_1", "switch", mi="2.p.1"),
         Converter("channel_2", "switch", mi="3.p.1"),
 
-        # Either Default/Wireless or Default/Atom, depending on hardware
+        # Either Default/Wireless or Default/Atom, depending on hard    ware
         BoolConv("wireless_1", "switch", mi="2.p.2", enabled=False),
         BoolConv("wireless_2", "switch", mi="3.p.2", enabled=False),
     ]
@@ -1956,6 +1956,22 @@ DEVICES += [{
         BoolConv("wireless_3", "switch", mi="4.p.2", enabled=False),
     ]
 }, {
+    # https://home.miot-spec.com/s/5045
+    5045: ["Linptech", "Mesh Triple Wall Switch QE1", "QE1SB-W3(MI)"],
+    "spec": [
+        Converter("channel_1", "switch", mi="2.p.1"),
+        Converter("channel_2", "switch", mi="3.p.1"),
+        Converter("channel_3", "switch", mi="4.p.1"),
+
+        BoolConv("wireless_1", "switch", mi="2.p.3"),
+        BoolConv("wireless_2", "switch", mi="3.p.3"),
+        BoolConv("wireless_3", "switch", mi="4.p.3"),
+
+        Converter("led", "switch", mi="5.p.1"),
+
+        Converter("compatible_mode", "switch", mi="7.p.4"),
+    ],
+},{
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1957,7 +1957,7 @@ DEVICES += [{
     ]
 }, {
     # https://home.miot-spec.com/s/5045
-    5045: ["Linptech", "Mesh Triple Wall Switch QE1", "QE1SB-W3(MI)"],
+    5045: ["Linptech", "Mesh Triple Wall Switch (no L)", "QE1"],
     "spec": [
         Converter("channel_1", "switch", mi="2.p.1"),
         Converter("channel_2", "switch", mi="3.p.1"),

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1957,7 +1957,7 @@ DEVICES += [{
     ]
 }, {
     # https://home.miot-spec.com/s/5045
-    5045: ["Linptech", "Mesh Triple Wall Switch (no L)", "QE1"],
+    5045: ["Linptech", "Mesh Triple Wall Switch (no L)", "QE1SB-W3(MI)"],
     "spec": [
         Converter("channel_1", "switch", mi="2.p.1"),
         Converter("channel_2", "switch", mi="3.p.1"),


### PR DESCRIPTION
Supports all features of the switch shown in MiHome App

Tested environment:
Homeassistant: 2023.3.6
Xiaomi Multimode Gateway 2 CN firmware: 1.0.6_0016

References: 
https://home.miot-spec.com/spec/linp.switch.q4s3
https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:switch:0000A003:linp-q4s3:1:0000C810
