### PR TITLE
Add LAN MAC to Multimode Gateway 2 device entry

### DIFF
--- a/custom_components/xiaomi_gateway3/core/entity.py
+++ b/custom_components/xiaomi_gateway3/core/entity.py
@@ -319,6 +319,10 @@ def setup_entity(
             connections = None
         elif device.type in (GATEWAY, BLE, MESH):
             connections = {(CONNECTION_NETWORK_MAC, device.mac)}
+            # Add alternative mac addresses if any.
+            if device.alternative_macs:
+                for m in device.alternative_macs:
+                    connections.add((CONNECTION_NETWORK_MAC, m))
         else:
             connections = {(CONNECTION_ZIGBEE, device.ieee)}
 

--- a/custom_components/xiaomi_gateway3/core/gateway/gate_mgw2.py
+++ b/custom_components/xiaomi_gateway3/core/gateway/gate_mgw2.py
@@ -42,9 +42,11 @@ class GateMGW2(
     async def mgw2_read_device(self, sh: shell.ShellMGW2):
         self.did = await sh.get_did()
         mac = await sh.get_wlan_mac()
+        # For MGW2 add eth0 mac address as alternative for connection.
+        ethmac = await sh.get_eth_mac()
         device = self.devices.get(self.did)
         if not device:
-            device = XDevice(GATEWAY, MODEL, self.did, mac)
+            device = XDevice(GATEWAY, MODEL, self.did, (mac, { ethmac }))
             device.extra = {"fw_ver": sh.ver}
         self.add_device(self.did, device)
 

--- a/custom_components/xiaomi_gateway3/core/shell/shell_mgw2.py
+++ b/custom_components/xiaomi_gateway3/core/shell/shell_mgw2.py
@@ -26,14 +26,6 @@ class ShellMGW2(ShellARM, ShellMultimode):
     def mesh_device_table(self) -> str:
         return "mesh_device_v3"
 
-    async def get_wlan_mac(self) -> str:
-        icmd = "MYPTS=`tty | sed 's/^\/dev\///'`; " + \
-               "RADDR=`who | grep \"$MYPTS\" | awk '{print $7;}' | tr -d '[]'`; " + \
-               "LADDR=`netstat -t | grep \"$RADDR\" | awk '{print $4;}' | sed 's/::ffff://' | cut -d: -f1`; " + \
-                "ip -o a | grep \"inet $LADDR\" | awk '{print $2;}'"
-
-        iface = await self.exec(icmd)
-        iface = iface.strip()
-        iface ="wlan0" if not iface in ("eth0", "wlan0") else iface
-        raw = await self.read_file("/sys/class/net/" + iface + "/address")
-        return raw.decode().rstrip().replace(":", "")
+    async def get_eth_mac(self) -> str:
+        raw = await self.exec("agetprop persist.sys.lan_mac")
+        return raw.rstrip().replace(":", "").lower()

--- a/custom_components/xiaomi_gateway3/core/shell/shell_mgw2.py
+++ b/custom_components/xiaomi_gateway3/core/shell/shell_mgw2.py
@@ -25,3 +25,15 @@ class ShellMGW2(ShellARM, ShellMultimode):
     @property
     def mesh_device_table(self) -> str:
         return "mesh_device_v3"
+
+    async def get_wlan_mac(self) -> str:
+        icmd = "MYPTS=`tty | sed 's/^\/dev\///'`; " + \
+               "RADDR=`who | grep \"$MYPTS\" | awk '{print $7;}' | tr -d '[]'`; " + \
+               "LADDR=`netstat -t | grep \"$RADDR\" | awk '{print $4;}' | sed 's/::ffff://' | cut -d: -f1`; " + \
+                "ip -o a | grep \"inet $LADDR\" | awk '{print $2;}'"
+
+        iface = await self.exec(icmd)
+        iface = iface.strip()
+        iface ="wlan0" if not iface in ("eth0", "wlan0") else iface
+        raw = await self.read_file("/sys/class/net/" + iface + "/address")
+        return raw.decode().rstrip().replace(":", "")


### PR DESCRIPTION
MGW2 reports wlan0 mac address irrespective to real connection type. It is not comfortable when connecting gateway over ethernet. The patch returns mac address of telnet connection used to control MGW2. All entities are created with useful ids. It works for my gateway.