### PR TITLE
Fix XiaomiNumber lacking definition of step attribute

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/base.py
+++ b/custom_components/xiaomi_gateway3/core/converters/base.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, TYPE_CHECKING
 
 from .const import *
+from homeassistant.components.number.const import DEFAULT_STEP
+
 
 if TYPE_CHECKING:
     from ..device import XDevice
@@ -103,6 +105,7 @@ class MathConv(Converter):
     min: float = -float("inf")
     multiply: float = 0
     round: int = None
+    step: float = DEFAULT_STEP
 
     def decode(self, device: "XDevice", payload: dict, value: float):
         if self.min <= value <= self.max:

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1860,7 +1860,7 @@ DEVICES += [{
         MathConv("distance", "sensor", mi="2.p.6"),
 
         Converter("led", "switch", mi="3.p.1", enabled=True),
-        MathConv("detect_range", "number", mi="3.p.2", min=0, max=8),
+        MathConv("detect_range", "number", mi="3.p.2", min=0, max=8,step=0.1),
         Converter("pir", "switch", mi="3.p.3", enabled=True),
 
         MapConv("occupancy_status", "sensor", mi="2.p.1", map={

--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -65,6 +65,14 @@ class BackToTheNumberEntity(NumberEntity):
         def _attr_native_max_value(self, value):
             self._attr_max_value = value
 
+        @property
+        def _attr_native_step(self):
+            return self._attr_step
+
+        @_attr_native_step.setter
+        def _attr_native_step(self, value):
+            self._attr_step = value
+
 
 # noinspection PyAbstractClass
 class XiaomiNumber(XEntity, BackToTheNumberEntity):
@@ -78,6 +86,8 @@ class XiaomiNumber(XEntity, BackToTheNumberEntity):
             self._attr_native_min_value = conv.min
         if hasattr(conv, "max"):
             self._attr_native_max_value = conv.max
+        if hasattr(conv, "step"):
+            self._attr_native_step = conv.step
 
     @callback
     def async_set_state(self, data: dict):


### PR DESCRIPTION
Addressing: https://github.com/AlexxIT/XiaomiGateway3/issues/1000

Defining  _attr_native_step in [NumberEntity](https://github.com/home-assistant/core/blob/dev/homeassistant/components/number/__init__.py) will fix the issue. Further improvement on Mathconv may be needed to make its 'step' attribute work perfectly with other existing attributes.

Before:
![v1](https://user-images.githubusercontent.com/19166775/230804356-8fc4c4ef-1cb9-4eb3-8f03-573b57ae0c64.gif)

After:
![v2](https://user-images.githubusercontent.com/19166775/230804361-3084e3ba-c568-4484-9ea4-383727575798.gif)

Tested environment:
HA core: 2023.3.6

