### PR TITLE
Include Mathconv.multiply for defining XiaomiNumber min max step attr

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -482,6 +482,9 @@ DEVICES += [{
 }, {
     "lumi.airrtc.agl001": ["Aqara", "Thermostat E1", "SRTS-A01"],
     "spec": [
+        # https://home.miot-spec.com/spec/lumi.airrtc.agl001
+        # The following code is very different to the spec defined in home.miot-spec.com
+        # thus leave unmodified
         BoolConv("climate", "climate", mi="4.21.85"),
         # 0: Manual module 1: Smart schedule mode 2: Antifreeze mode 3: Installation mode
         MapConv("mode", mi="14.51.85", parent="climate", map={0: "heat", 2: "auto"}),
@@ -1579,6 +1582,7 @@ DEVICES += [{
     ],
 }, {
     # https://www.ixbt.com/live/chome/umnaya-rozetka-xiaomi-zncz01zm-s-energomonitoringom-i-bluetooth-mesh-integraciya-v-home-assistant.html
+    # https://home.miot-spec.com/spec/zimi.plug.zncz01
     3083: ["Xiaomi", "Electrical Outlet", "ZNCZ01ZM"],
     "spec": [
         Converter("outlet", "switch", mi="2.p.1"),
@@ -1586,7 +1590,7 @@ DEVICES += [{
         Converter("led", "switch", mi="4.p.1", enabled=False),
         Converter("power_protect", "switch", mi="7.p.1", enabled=False),
         MathConv("power_value", "number", mi="7.p.2", multiply=0.01,
-                 min=0, max=1638400, enabled=False),
+                 min=0, max=163840000, enabled=False),
     ],
 }, {
     2093: ["PTX", "Mesh Triple Wall Switch", "PTX-TK3/M"],
@@ -1934,8 +1938,8 @@ DEVICES += [{
         # Inching mode
         BoolConv("inching_mode", "switch", mi="2.p.2"),
         MapConv("inching_state", "select", mi="3.p.1", map={False: "off", True: "on"}),
-        MathConv("inching_time", "number", mi="3.p.2", multiply=0.5, min=1, max=7199,
-                 round=1),
+        MathConv("inching_time", "number", mi="3.p.2", multiply=0.5, min=1, max=7200,
+                 step=1, round=1),
 
         # LED
         MapConv("led", "select", mi="4.p.1", map={

--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -82,12 +82,13 @@ class XiaomiNumber(XEntity, BackToTheNumberEntity):
         if self.attr in UNITS:
             self._attr_native_unit_of_measurement = UNITS[self.attr]
 
+        multiply = conv.multiply if hasattr(conv, "multiply") and conv.multiply else 1
         if hasattr(conv, "min"):
-            self._attr_native_min_value = conv.min
+            self._attr_native_min_value = conv.min*multiply
         if hasattr(conv, "max"):
-            self._attr_native_max_value = conv.max
+            self._attr_native_max_value = conv.max*multiply
         if hasattr(conv, "step"):
-            self._attr_native_step = conv.step
+            self._attr_native_step = conv.step*multiply
 
     @callback
     def async_set_state(self, data: dict):

--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -1,4 +1,5 @@
 from homeassistant.components.number import NumberEntity
+from homeassistant.components.number.const import DEFAULT_STEP
 from homeassistant.const import (
     MAJOR_VERSION,
     MINOR_VERSION,
@@ -87,8 +88,8 @@ class XiaomiNumber(XEntity, BackToTheNumberEntity):
             self._attr_native_min_value = conv.min*multiply
         if hasattr(conv, "max"):
             self._attr_native_max_value = conv.max*multiply
-        if hasattr(conv, "step"):
-            self._attr_native_step = conv.step*multiply
+
+        self._attr_native_step = (conv.step if hasattr(conv, "step") else DEFAULT_STEP)*multiply
 
     @callback
     def async_set_state(self, data: dict):


### PR DESCRIPTION
States updates and events sent by DEVICE have to be processed by CONVERTER before reaching ENTITY. 
MathConv (CONVERTER) multiplies all values come from DEVICE by its attribute "multiply" before passing them to XiaomiNumber (ENTITY). However, XiaomiNumber attributes "_attr_native_min_value", "_attr_native_max_value" and "_attr_native_step_value" are directly acquired from MathConv attributes "min", "max" and "step" and did not account for the effect of MathConv attribute "multiply". This commit is to fix this issue as well as make sure the previously defined devices will be working as previously with this update.