### PR TITLE
Update the XMZNMS09LM lock support  for GW 1.54.090

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1352,13 +1352,37 @@ DEVICES += [{
 }, {
     6017: ["Xiaomi", "Face Recognition Smart Door Lock", "XMZNMS09LM"],
     "spec": [
-        MiBeacon,
-        Converter("action", "sensor"),
-        Converter("battery", "sensor"),
-        Converter("doorbell", "sensor"),
-        Converter("contact", "binary_sensor"),
-        Converter("lock", "binary_sensor"),
+        #sensor action
+        EventConv("action", "sensor", mi="2.e.1020"),
+        Converter("key_id", mi="2.p.1"),
+        Converter("method_id", mi="2.p.5"),
+        MapConv("method", mi="2.p.5", map={
+            1: "mobile", 2: "fingerprint", 3: "password", 4: "nfc", 5: "face", 8: "key",
+            9: "one_time_password", 10: "periodic_password", 12: "coerce", 15: "manual", 16: "auto"
+        }),
+        Converter("action_id", mi="2.p.3"),
+        MapConv("action", mi="2.p.3", map={
+            1: "lock", 2: "unlock", 3: "lock_outside", 4: "lock_inside",
+            5: "unlock_inside",6: "enable_child_lock",7: "disable_child_lock", 8: "enable_away", 9: "disable_away"
+        }),
+        MapConv("position", mi="2.p.6", map={1: "indoor", 2: "outdoor", 3: "not tell indoor or outdoor"}),
+        Converter("timestamp", mi="2.p.2"),  # lock timestamp
+        # doorbell
+        EventConv("action", mi="5.e.1006", value="doorbell"),
+        Converter("timestamp", mi="5.p.1"),  # doorbell timestamp
+        
+        #doorbell sensor
+        Converter("doorbell","sensor",mi="5.p.1"),
+        #contact binary_sensor
+        MapConv("contact", "binary_sensor",mi="2.p.3", map={
+            1: False, 2: True}),
+        #lock binary_sensor
+        MapConv("lock", "binary_sensor",mi="2.p.3", map={
+            1: False, 2: True}),
+        # battery sensor
+        Converter("battery", "sensor", mi="4.p.1003"),
     ],
+    "ttl": "25h"
 }, {
     # https://github.com/AlexxIT/XiaomiGateway3/issues/657
     2444: ["Xiaomi", "Door Lock", "XMZNMST02YD"],


### PR DESCRIPTION
After upgrade the gw firmware to 1.54.090，all the sensors are unvalid. In the debug log, I can't get the old format data like https://github.com/AlexxIT/XiaomiGateway3/issues/874.Only the fallow data:
```
2023-04-25 10:50:45 [D] 192.168.31.136 [MQTT] miio/report_ack b'{"id":485704111,"result":{"operation":"ble_spec_query_prod","pdid":6017,"ttl":1800,"size":5,"pidrule":[{"siid":3,"piid":1021,"intvl":600,"delta":1,"type":"uint8"},{"siid":4,"piid":1003,"intvl":600,"delta":1,"type":"uint8"}],"eidrule":[{"siid":2,"eiid":1007,"intvl":0,"delta":0,"piids":[{"piid":2,"type":"uint32","name":"Current Time"},{"piid":4,"type":"uint8","name":"Abnormal Condition"}]},{"siid":2,"eiid":1020,"intvl":0,"delta":0,"piids":[{"piid":1,"type":"uint16","name":"Operation ID"},{"piid":2,"type":"uint32","name":"Current Time"},{"piid":3,"type":"uint8","name":"Lock Action"},{"piid":5,"type":"uint8","name":"Operation Method"},{"piid":6,"type":"uint8","name":"Operation Position"}]},{"siid":5,"eiid":1006,"intvl":0,"delta":0,"piids":[{"piid":1,"type":"uint32","name":"Current Time"}]}]}}'

2023-04-26 10:11:30 [D] 192.168.31.136 [MQTT] miio/report b'{"id":1541408471,"method":"event_occured","params":{"did":"1038140837","siid":2,"eiid":1020,"tid":243,"arguments":[{"piid":1,"value":5},{"piid":2,"value":1682475092},{"piid":3,"value":2},{"piid":5,"value":2},{"piid":6,"value":2}]},"type":6}'

2023-04-26 10:11:31 [D] 192.168.31.136 [MQTT] miio/report b'{"id":678058474,"method":"properties_changed","params":[{"did":"1038140837","siid":3,"piid":1021,"value":2,"tid":244}],"type":6}'

2023-04-26 10:12:01 [D] 192.168.31.136 [MQTT] miio/report b'{"id":374899481,"method":"event_occured","params":{"did":"1038140837","siid":2,"eiid":1007,"tid":245,"arguments":[{"piid":2,"value":1682475123},{"piid":4,"value":23}]},"type":6}'

2023-04-26 10:12:17 [D] 192.168.31.136 [MQTT] miio/report b'{"id":819866484,"method":"event_occured","params":{"did":"1038140837","siid":2,"eiid":1020,"tid":246,"arguments":[{"piid":1,"value":0},{"piid":2,"value":1682475139},{"piid":3,"value":1},{"piid":5,"value":16},{"piid":6,"value":3}]},"type":6}'
 ```

So I update the parse code which is similar with the https://github.com/AlexxIT/XiaomiGateway3/issues/973 for GW 1.54.090