### PR TITLE
Add Support for Xiaomi Smart Safe Cayo Anno 30Z Device

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1485,6 +1485,22 @@ DEVICES += [{
     ],
     "ttl": "25h"
 }, {
+    # https://home.miot-spec.com/spec/lcrmcr.safe.ms30b
+    1393: ["Xiaomi", "Smart Safe Cayo Anno 30Z", "lcrmcr.safe.ms30b"],
+    "spec": [
+        MiBeacon, BLEAction,
+
+        MapConv("method", mi="2.p.1", map={
+            0: "mobile", 2: "fingerprint", 4: "key",
+        }),
+        Converter("action_id", mi="2.p.2"),
+        MapConv("abnormal_condition", mi="2.p.3", map={
+            1: "wrong_fingerprint", 2: "lockpicking", 4: "timeout_not_locked",
+        }),
+        Converter("battery", "sensor"),
+    ],
+    "ttl": "25h"
+}, {
     # BLE devices can be supported witout spec. New spec will be added
     # "on the fly" when device sends them. But better to rewrite right spec for
     # each device

--- a/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
+++ b/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
@@ -33,7 +33,8 @@ BLE_LOCK_ACTION = {
     0b0101: "Lock inside the door",
     0b0110: "Turn on child lock",
     0b0111: "Turn off child lock",
-    0b1111: None,
+    0b1000: "Lock outside the door",
+    0b1111: "Abnormal",
 }
 BLE_LOCK_METHOD = {
     0b0000: "bluetooth",
@@ -47,7 +48,7 @@ BLE_LOCK_METHOD = {
     0b1000: "coercion",
     0b1010: "manual",
     0b1011: "automatic",
-    0b1111: None,
+    0b1111: "abnormal",
 }
 BLE_LOCK_ERROR = {
     0xC0DE0000: "Frequent unlocking with incorrect password",
@@ -72,6 +73,7 @@ BLE_LOCK_ERROR = {
     0xC0DE1002: "The fingerprint sensor is abnormal",
     0xC0DE1003: "The accessory battery is low",
     0xC0DE1004: "Mechanical failure",
+    0xC0DE1005: "the lock sensor is faulty",
 }
 
 BLE_SPEC_LOCK_ACTION = {


### PR DESCRIPTION
This pull request adds support for the Xiaomi Smart Safe Cayo Anno 30Z. It includes new BLEAction and MiBeacon converters, mapping for lock method and abnormal conditions, and sensor readings for action ID, abnormal condition, time, and battery.