### PR TITLE
ZXiaomiBrightnessConv have to return integer brightness value.

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/zigbee.py
+++ b/custom_components/xiaomi_gateway3/core/converters/zigbee.py
@@ -462,7 +462,7 @@ class ZXiaomiBrightnessConv(Converter):
     """
 
     def decode(self, device: "XDevice", payload: dict, value: Any):
-        payload[self.attr] = value / 100.0 * 255.0
+        payload[self.attr] = max (0, min(255, round(value / 100.0 * 255.0)))
 
     def encode(self, device: "XDevice", payload: dict, value: Any):
         # brightness and transition in seconds


### PR DESCRIPTION
I have Aqara ZNLDP12LM lamp connected. All seems to be OK until I call <code>light.turn_on(brightness_step: xxxx)</code> or <code>light.turn_on(brightness_step_pct: xxxx)</code> service. What's going on:

> 2023-07-03 23:14:19 [D] 192.168.84.65 [LUMI] 0x00158d00075031d6 (0x8eaa) recv {'new_resets': 0, 'resets': 59, 'fw_ver': 23, 'parent': '0x9edf', 'light': True, 'brightness': 119.85, 'color_temp': 256}
> 2023-07-03 23:14:24 [D] 192.168.84.65 [SLBS] 0x00158d00075031d6 (0x8eaa) send {'commands': [{'commandcli': 'zcl level-control o-mv-to-level 120 10'}, {'commandcli': 'send 0x8eaa 1 1'}]}
> 2023-07-03 23:14:24 [D] 192.168.84.65 [ZIGB] 0x00158d00075031d6 0x8eaa send {'endpoint': 1, 'seq': 119, 'cluster': 'level', 'command_id': 4, 'command': 'move_to_level_with_on_off', 'value': move_to_level_with_on_off(level=120, transition_time=10)}
> 2023-07-03 23:14:24 [D] 192.168.84.65 [ZIGB] 0x00158d00075031d6 (0x8eaa) recv {'endpoint': 1, 'seq': 127, 'cluster': 'level', 'command': 'Report_Attributes', 'current_level': 120, 61440: 117440631}
> 2023-07-03 23:14:24 [D] 192.168.84.65 [ZIGB] 0x00158d00075031d6 (0x8eaa) recv {'endpoint': 1, 'seq': 128, 'cluster': 'level', 'command': 'Report_Attributes', 'current_level': 120, 61440: 9349632}
> 
> // Following value returned from converter: **119.85**
> 2023-07-03 23:14:24 [D] 192.168.84.65 [LUMI] 0x00158d00075031d6 (0x8eaa) recv {'brightness': 119.85}
> 
> // Now I call <code>light.turn_on(entity_id: light.my_aqara_light, brightness_step: **20**)</code>. It fails. **139.85 == 119.85 + 20**.
> 2023-07-03 23:15:02 [D] 192.168.84.65 [SLBS] 0x00158d00075031d6 (0x8eaa) send {'commands': [{'commandcli': 'zcl level-control o-mv-to-level 139.85 10'}, {'commandcli': 'send 0x8eaa 1 1'}]}

So, with YandexSmartHome integration configured, the command "Alice, make my light brighter" doesn't work. All other commands work fine, as they are translated to <code>light.turn_on(brightness: <integer value>)</code> or <code>light.turn_on(brightness_pct: <integer value>)</code>.

Not sure about other Xiaomi lights. Maybe it's better to redefine converter for ZNLDP12LM only.
