### PR TITLE
fix sensor proportion error for XMZNCXB01QM（Mesh Power Strip 2）

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1897,10 +1897,10 @@ DEVICES += [{
         Converter("mode", "switch", mi="2.p.2"),  # int8
         MathConv("chip_temperature", "sensor", mi="2.p.3", round=2,
                  enabled=False),  # float
-        MathConv("energy", "sensor", mi="3.p.1", multiply=0.001, round=2),
+        MathConv("energy", "sensor", mi="3.p.1", multiply=0.1, round=2),
         MathConv("power", "sensor", mi="3.p.2", round=2),  # float
-        MathConv("voltage", "sensor", mi="3.p.3"),  # float
-        MathConv("current", "sensor", mi="3.p.4"),  # float
+        MathConv("voltage", "sensor", mi="3.p.3", multiply=0.001, round=2),  # float
+        MathConv("current", "sensor", mi="3.p.4", multiply=0.001, round=2),  # float
     ]
 }, {
     3129: ["Xiaomi", "Smart Curtain Motor", "MJSGCLBL01LM"],


### PR DESCRIPTION
fix sensor proportion error

before：
![error](https://github.com/AlexxIT/XiaomiGateway3/assets/78073839/d3c86f27-6ae6-476a-a1e3-69055ec1e850)

 after：
![true](https://github.com/AlexxIT/XiaomiGateway3/assets/78073839/2caa9020-df95-4a67-aec4-6de62c47d649)


energy  0.23 kWh   →→ 22.7 kWh
voltage 221612 V   →→ 219.48 V
current 479 A         →→ 0.83 A