### PR TITLE
Fix formaldehyde scale for ble device 735 

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
+++ b/custom_components/xiaomi_gateway3/core/converters/mibeacon.py
@@ -274,7 +274,10 @@ class MiBeaconConv(Converter):
             payload["opening"] = bool(data[0] == 0)
 
         elif eid == 0x1010 and len(data) == 2:  # 4112
-            payload["formaldehyde"] = int.from_bytes(data, "little") / 1000.0
+            if device.model == 1809:
+                payload["formaldehyde"] = int.from_bytes(data, "little") / 1000.0
+            else:
+                payload["formaldehyde"] = int.from_bytes(data, "little") / 100.0
 
         elif eid == 0x1012 and len(data) == 1:  # 4114
             # hass: On means open, Off means closed


### PR DESCRIPTION
As is mentioned in https://github.com/AlexxIT/XiaomiGateway3/issues/1177, different devices use different unit for formaldehyde.
Therefore I add an if-else statement to make both devices work.