### PR TITLE
Revert entity name of RS1BB from `water_leak` to `moisture`

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -1359,9 +1359,8 @@ DEVICES += [{
 }, {
     16143: ["Linptech", "Submersion Sensor", "RS1BB"],
     "spec": [
-        MiBeacon, BLEWaterLeak, BLEBattery,
-        Converter("water_leak", mi="2.p.1006"),
-        Converter("battery", mi="3.p.1003"),
+        Converter("moisture", "binary_sensor", mi="2.p.1006"),
+        Converter("battery", "sensor", mi="3.p.1003"),
     ],
 }, {
     # https://home.miot-spec.com/spec/linp.senpres.ps1bb


### PR DESCRIPTION
Maybe a breaking change.

Change the entity name of RS1BB from `water_leak` to `moisture`, to better correspond to [`BinarySensorDeviceClass.MOISTURE`](https://developers.home-assistant.io/docs/core/entity/binary-sensor#available-device-classes).

But if you feel this is unnecessary, just leave it alone.