### PR TITLE
Add support for light effect and effect_list

### DIFF
--- a/custom_components/xiaomi_gateway3/light.py
+++ b/custom_components/xiaomi_gateway3/light.py
@@ -48,6 +48,9 @@ class XiaomiLight(XEntity, LightEntity, RestoreEntity):
                 elif hasattr(conv, "mink") and hasattr(conv, "maxk"):
                     self._attr_min_mireds = int(1000000 / conv.maxk)
                     self._attr_max_mireds = int(1000000 / conv.mink)
+            elif conv.attr == ATTR_EFFECT:
+                self._attr_supported_features |= LightEntityFeature.EFFECT
+                self._attr_effect_list = list(conv.map.values())
 
     @callback
     def async_set_state(self, data: dict):
@@ -58,12 +61,15 @@ class XiaomiLight(XEntity, LightEntity, RestoreEntity):
             self._attr_brightness = data[ATTR_BRIGHTNESS]
         if ATTR_COLOR_TEMP in data:
             self._attr_color_temp = data[ATTR_COLOR_TEMP]
+        if ATTR_EFFECT in data:
+            self._attr_effect = data[ATTR_EFFECT]
 
     @callback
     def async_restore_last_state(self, state: str, attrs: dict):
         self._attr_is_on = state == STATE_ON
         self._attr_brightness = attrs.get(ATTR_BRIGHTNESS)
         self._attr_color_temp = attrs.get(ATTR_COLOR_TEMP)
+        self._attr_effect = attrs.get(ATTR_EFFECT)
 
     async def async_update(self):
         await self.device_read(self.subscribed_attrs)


### PR DESCRIPTION
To implement this in your device, add similar converters like the one down below to devices.py.

> MapConv("effect", mi="1.p.1", parent="light", map={0: "Day", 1: "Night"})