### PR TITLE
Use round() to translate between mired and kelvin

### DIFF
--- a/custom_components/xiaomi_gateway3/light.py
+++ b/custom_components/xiaomi_gateway3/light.py
@@ -46,8 +46,8 @@ class XiaomiLight(XEntity, LightEntity, RestoreEntity):
                     self._attr_min_mireds = conv.minm
                     self._attr_max_mireds = conv.maxm
                 elif hasattr(conv, "mink") and hasattr(conv, "maxk"):
-                    self._attr_min_mireds = int(1000000 / conv.maxk)
-                    self._attr_max_mireds = int(1000000 / conv.mink)
+                    self._attr_min_mireds = round(1000000 / conv.maxk)
+                    self._attr_max_mireds = round(1000000 / conv.mink)
             elif conv.attr == ATTR_EFFECT:
                 self._attr_supported_features |= LightEntityFeature.EFFECT
                 self._attr_effect_list = list(conv.map.values())


### PR DESCRIPTION
The color temperature range for my light is `2700 - 6500`. With previous kelvin to mired translation, color temperature range shown in the entity is `2702 - 6535`. The max color temperature has exceeded what the device is capable of.

Using `round()` for the translation, the end result is `2702 - 6493`. So it seems to be reasonable to use `round()` instead of `int()`.