### PR TITLE
Support giot.switch.v3oodm

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -3125,6 +3125,26 @@ DEVICES += [{
         Converter("backlight", "switch", mi="8.p.1"),
     ],
 }, {
+    # https://home.miot-spec.com/s/giot.plug.v3oodm
+    10944: ["Unknown", "Mesh Smart Switch V3", "giot.switch.v3oodm"],
+    "spec": [
+        Converter("switch", "switch", mi="2.p.1"),
+        MapConv("power_on_state", "select", mi="2.p.3", map={
+            0: "off", 1: "on", 2: "previous"
+        }),
+
+        # Inching mode
+        BoolConv("inching_mode", "switch", mi="2.p.2"),
+        MapConv("inching_state", "select", mi="3.p.1", map={False: "off", True: "on"}),
+        MathConv("inching_time", "number", mi="3.p.2", multiply=0.5, min=1, max=7200,
+                 step=1, round=1),
+
+        # LED
+        MapConv("led", "select", mi="4.p.1", map={
+            0: "follow_switch", 1: "opposite_to_switch", 2: "off", 3: "on"
+        })
+    ]
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool


### PR DESCRIPTION
support #1218 giot.switch.v3oodm 
[https://home.miot-spec.com/spec/giot.switch.v3oodm](https://home.miot-spec.com/spec/giot.switch.v3oodm)

giot.switch.v3oodm specs is just the same as `10920: ["Unknown", "Mesh Smart Plug V3", "giot.plug.v3shsm"]`
But this type is switch not plug, so I add a new spec for this device