### PR TITLE
Fix error in HA 2024.1 (HA>=2023.1)

### DIFF
--- a/custom_components/xiaomi_gateway3/alarm_control_panel.py
+++ b/custom_components/xiaomi_gateway3/alarm_control_panel.py
@@ -1,8 +1,5 @@
 from homeassistant.components.alarm_control_panel import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_TRIGGER,
+    AlarmControlPanelEntityFeature,
     AlarmControlPanelEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -31,10 +28,10 @@ async def async_setup_entry(
 class XiaomiAlarm(XEntity, AlarmControlPanelEntity):
     _attr_code_arm_required = False
     _attr_supported_features = (
-        SUPPORT_ALARM_ARM_HOME
-        | SUPPORT_ALARM_ARM_AWAY
-        | SUPPORT_ALARM_ARM_NIGHT
-        | SUPPORT_ALARM_TRIGGER
+        AlarmControlPanelEntityFeature.ARM_HOME
+        | AlarmControlPanelEntityFeature.ARM_AWAY
+        | AlarmControlPanelEntityFeature.ARM_NIGHT
+        | AlarmControlPanelEntityFeature.TRIGGER
     )
 
     @callback

--- a/custom_components/xiaomi_gateway3/climate.py
+++ b/custom_components/xiaomi_gateway3/climate.py
@@ -1,6 +1,5 @@
 from homeassistant.components.climate import *
 from homeassistant.components.climate.const import *
-from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -11,9 +10,9 @@ from .core.entity import XEntity, setup_entity
 from .core.gateway import XGateway
 
 ACTIONS = {
-    HVAC_MODE_OFF: CURRENT_HVAC_OFF,
-    HVAC_MODE_COOL: CURRENT_HVAC_COOL,
-    HVAC_MODE_HEAT: CURRENT_HVAC_HEAT,
+    HVACMode.OFF: HVACAction.OFF,
+    HVACMode.COOL: HVACAction.COOLING,
+    HVACMode.HEAT: HVACAction.HEATING,
 }
 
 
@@ -35,10 +34,10 @@ class XiaomiClimate(XEntity, ClimateEntity):
     _attr_fan_mode = None
     _attr_fan_modes = [FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO]
     _attr_hvac_mode = None
-    _attr_hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_HEAT]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT]
     _attr_precision = PRECISION_WHOLE
-    _attr_supported_features = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE_RANGE | ClimateEntityFeature.FAN_MODE
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     # support only KTWKQ03ES for now
     _attr_max_temp = 30
     _attr_min_temp = 17
@@ -77,9 +76,9 @@ class XiaomiClimate(XEntity, ClimateEntity):
 # noinspection PyAbstractClass
 class AqaraE1(XEntity, ClimateEntity):
     _attr_hvac_mode = None
-    _attr_hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_AUTO]
-    _attr_supported_features = SUPPORT_TARGET_TEMPERATURE
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO]
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_max_temp = 30
     _attr_min_temp = 5
     _attr_target_temperature_step = 0.5
@@ -101,7 +100,7 @@ class AqaraE1(XEntity, ClimateEntity):
         if self._enabled is None or self._mode is None:
             return
 
-        self._attr_hvac_mode = self._mode if self._enabled else HVAC_MODE_OFF
+        self._attr_hvac_mode = self._mode if self._enabled else HVACMode.OFF
 
     async def async_update(self):
         await self.device_read(self.subscribed_attrs)
@@ -110,9 +109,9 @@ class AqaraE1(XEntity, ClimateEntity):
         await self.device_send({"target_temp": kwargs[ATTR_TEMPERATURE]})
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
-        if hvac_mode in (HVAC_MODE_HEAT, HVAC_MODE_AUTO):
+        if hvac_mode in (HVACMode.HEAT, HVACMode.AUTO):
             payload = {"mode": hvac_mode}
-        elif hvac_mode == HVAC_MODE_OFF:
+        elif hvac_mode == HVACMode.OFF:
             payload = {"climate": False}
         else:
             return

--- a/custom_components/xiaomi_gateway3/number.py
+++ b/custom_components/xiaomi_gateway3/number.py
@@ -1,7 +1,7 @@
 from homeassistant.components.number import NumberEntity
 from homeassistant.components.number.const import DEFAULT_STEP
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import LENGTH_METERS, TIME_SECONDS
+from homeassistant.const import UnitOfLength, UnitOfTime
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -23,8 +23,8 @@ async def async_setup_entry(
 
 
 UNITS = {
-    "approach_distance": LENGTH_METERS,
-    "occupancy_timeout": TIME_SECONDS,
+    "approach_distance": UnitOfLength.METERS,
+    "occupancy_timeout": UnitOfTime.SECONDS,
 }
 
 

--- a/custom_components/xiaomi_gateway3/sensor.py
+++ b/custom_components/xiaomi_gateway3/sensor.py
@@ -38,27 +38,18 @@ UNITS = {
     "humidity": PERCENTAGE,
     # zb light and motion and ble flower - lux
     "illuminance": LIGHT_LUX,
-    # Deprecated: please use UnitOfPower.WATT.
-    "power": POWER_WATT,
-    # Deprecated: please use UnitOfElectricPotential.VOLT.
-    "voltage": ELECTRIC_POTENTIAL_VOLT,
-    # Deprecated: please use UnitOfElectricCurrent.AMPERE.
-    "current": ELECTRIC_CURRENT_AMPERE,
-    # Deprecated: please use UnitOfPressure.HPA
-    "pressure": PRESSURE_HPA,
-    # Deprecated: please use UnitOfTemperature.CELSIUS
-    "temperature": TEMP_CELSIUS,
-    # Deprecated: please use UnitOfEnergy.KILO_WATT_HOUR.
-    "energy": ENERGY_KILO_WATT_HOUR,
-    # Deprecated: please use UnitOfTemperature.CELSIUS
-    "chip_temperature": TEMP_CELSIUS,
+    "power": UnitOfPower.WATT,
+    "voltage": UnitOfElectricPotential.VOLT,
+    "current": UnitOfElectricCurrent.AMPERE,
+    "pressure": UnitOfPressure.HPA,
+    "temperature": UnitOfTemperature.CELSIUS,
+    "energy": UnitOfEnergy.KILO_WATT_HOUR,
+    "chip_temperature": UnitOfTemperature.CELSIUS,
     "conductivity": CONDUCTIVITY,
     "gas_density": "% LEL",
-    # Deprecated: please use UnitOfTime.SECONDS.
-    "idle_time": TIME_SECONDS,
+    "idle_time": UnitOfTime.SECONDS,
     "linkquality": "lqi",
-    # Deprecated: please use UnitOfPower.WATT.
-    "max_power": POWER_WATT,
+    "max_power": UnitOfPower.WATT,
     "moisture": PERCENTAGE,
     "msg_received": "msg",
     "msg_missed": "msg",
@@ -68,10 +59,9 @@ UNITS = {
     "smoke_density": "% obs/ft",
     "supply": PERCENTAGE,
     "tvoc": CONCENTRATION_PARTS_PER_BILLION,
-    # Deprecated: please use UnitOfLength.METERS.
-    "distance": LENGTH_METERS,
-    "occupancy_duration": TIME_SECONDS,
-    "occupancy_distance": LENGTH_METERS,
+    "distance": UnitOfLength.METERS,
+    "occupancy_duration": UnitOfTime.SECONDS,
+    "occupancy_distance": UnitOfLength.METERS,
     "formaldehyde": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
     # "link_quality": "lqi",
     # "rssi": "dBm",
@@ -79,8 +69,7 @@ UNITS = {
     # "msg_missed": "msg",
     # "unresponsive": "times"
     "power_replenishment": "mAh",
-    # Deprecated: please use UnitOfElectricCurrent.MILLIAMPERE.
-    "realtime_current_in": ELECTRIC_CURRENT_MILLIAMPERE,
+    "realtime_current_in": UnitOfElectricCurrent.MILLIAMPERE,
 }
 
 # https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics


### PR DESCRIPTION
Replaced deprecated constants.

https://developers.home-assistant.io/blog/2023/12/19/constant-deprecation

This will increase the minimum HA version requirement to 2023.1

Fix #1245 