### PR TITLE
fix climate device init setup error and support Scdvb HAVC

### DIFF
--- a/custom_components/xiaomi_gateway3/climate.py
+++ b/custom_components/xiaomi_gateway3/climate.py
@@ -56,18 +56,23 @@ class XiaomiClimate(XEntity, ClimateEntity):
     _attr_max_temp = 30
     _attr_min_temp = 17
     _attr_target_temperature_step = 1
+    _enabled = None
+    _mode = None
 
     @callback
     def async_set_state(self, data: dict):
+        self._enabled = data.get("power")
         self._attr_current_temperature = data.get("current_temp")
         self._attr_fan_mode = data.get("fan_mode")
         self._attr_hvac_mode = data.get("hvac_mode")
+        self._mode = data.get("hvac_mode")
         # better support HomeKit
         # https://github.com/AlexxIT/XiaomiGateway3/issues/707#issuecomment-1099109552
         self._attr_hvac_action = ACTIONS.get(self._attr_hvac_mode)
         # fix scenes with turned off climate
         # https://github.com/AlexxIT/XiaomiGateway3/issues/101#issuecomment-757781988
         self._attr_target_temperature = data.get("target_temp", 0)
+        self._attr_hvac_mode = self._mode if self._enabled else HVACMode.OFF
 
     async def async_update(self):
         await self.device_read(self.subscribed_attrs)

--- a/custom_components/xiaomi_gateway3/climate.py
+++ b/custom_components/xiaomi_gateway3/climate.py
@@ -50,7 +50,7 @@ class XiaomiClimate(XEntity, ClimateEntity):
     _attr_hvac_mode = None
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT]
     _attr_precision = PRECISION_WHOLE
-    _attr_supported_features = ClimateEntityFeature.FAN_MODE
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     # support only KTWKQ03ES for now
     _attr_max_temp = 30
@@ -137,7 +137,7 @@ class ScdvbHAVC(XEntity, ClimateEntity):
     _attr_hvac_mode = None
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.AUTO, HVACMode.DRY, HVACMode.FAN_ONLY]
     _attr_precision = PRECISION_WHOLE
-    _attr_supported_features = ClimateEntityFeature.FAN_MODE
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_max_temp = 32
     _attr_min_temp = 16

--- a/custom_components/xiaomi_gateway3/climate.py
+++ b/custom_components/xiaomi_gateway3/climate.py
@@ -23,6 +23,8 @@ ACTIONS = {
     HVACMode.OFF: HVACAction.OFF,
     HVACMode.COOL: HVACAction.COOLING,
     HVACMode.HEAT: HVACAction.HEATING,
+    HVACMode.DRY: HVACAction.DRYING,
+    HVACMode.FAN_ONLY: HVACAction.FAN,
 }
 
 
@@ -32,6 +34,8 @@ async def async_setup_entry(
     def new_entity(gateway: XGateway, device: XDevice, conv: Converter) -> XEntity:
         if conv.mi == "4.21.85":
             return AqaraE1(gateway, device, conv)
+        if device.model == 14050:
+            return ScdvbHAVC(gateway, device, conv)
         else:
             return XiaomiClimate(gateway, device, conv)
 
@@ -46,9 +50,7 @@ class XiaomiClimate(XEntity, ClimateEntity):
     _attr_hvac_mode = None
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT]
     _attr_precision = PRECISION_WHOLE
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE_RANGE | ClimateEntityFeature.FAN_MODE
-    )
+    _attr_supported_features = ClimateEntityFeature.FAN_MODE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     # support only KTWKQ03ES for now
     _attr_max_temp = 30
@@ -128,3 +130,59 @@ class AqaraE1(XEntity, ClimateEntity):
         else:
             return
         await self.device_send(payload)
+
+class ScdvbHAVC(XEntity, ClimateEntity):
+    _attr_fan_mode = None
+    _attr_fan_modes = [FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO]
+    _attr_hvac_mode = None
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.AUTO, HVACMode.DRY, HVACMode.FAN_ONLY]
+    _attr_precision = PRECISION_WHOLE
+    _attr_supported_features = ClimateEntityFeature.FAN_MODE
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_max_temp = 32
+    _attr_min_temp = 16
+    _attr_target_temperature_step = 1
+
+    _enabled = None
+    _mode = None
+    @callback
+    def async_set_state(self, data: dict):
+        if "climate" in data:
+            self._enabled = data["climate"]
+        if "hvac_mode" in data:
+            self._mode = data["hvac_mode"]
+        if "fan_mode" in data:
+            self._attr_fan_mode = data["fan_mode"]
+        if "current_temp" in data:
+            self._attr_current_temperature = data["current_temp"]
+        if "target_temp" in data:
+            self._attr_target_temperature = data["target_temp"]
+
+        if self._enabled is None or self._mode is None:
+            return
+
+        self._attr_hvac_mode = self._mode if self._enabled else HVACMode.OFF
+    async def async_update(self):
+        await self.device_read(self.subscribed_attrs)
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        if kwargs[ATTR_TEMPERATURE] == 0:
+            return
+        await self.device_send({"target_temp": kwargs[ATTR_TEMPERATURE]})
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        if not self._enabled:
+            await self.device_send({"climate": True})
+            self._attr_hvac_mode = self._mode
+        await self.device_send({"fan_mode": fan_mode})
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        if hvac_mode == HVACMode.OFF:
+            await self.device_send({"climate": False})
+        else:
+            if not self._enabled:
+                await self.device_send({"climate": True})
+			 # better support HomeKit
+            if hvac_mode == HVACMode.AUTO:
+                hvac_mode = self._mode
+            await self.device_send({"hvac_mode": hvac_mode})

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -3229,6 +3229,15 @@ DEVICES += [{
         })
     ]
 }, {
+    14050: ["Scdvb", "Air Conditioner", "scdvb.aircondition.acm"],
+    "spec": [
+        Converter("climate", "climate", mi="2.p.1"),
+        MapConv("hvac_mode", mi="2.p.2", map={0: "cool", 1: "heat", 2: "fan_only", 3: "dry"}, parent="climate"),
+        MapConv("fan_mode", mi="3.p.1", map={0: "auto", 1: "low", 2: "medium", 3: "high"}, parent="climate"),
+        Converter("current_temp", mi="4.p.1", parent="climate"),
+        Converter("target_temp", mi="2.p.3", parent="climate"),
+    ],
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         Converter("switch", "switch", mi="2.p.1", enabled=None),  # bool

--- a/custom_components/xiaomi_gateway3/core/converters/devices.py
+++ b/custom_components/xiaomi_gateway3/core/converters/devices.py
@@ -463,8 +463,8 @@ DEVICES += [{
     # https://github.com/AlexxIT/XiaomiGateway3/issues/101
     "lumi.airrtc.tcpecn02": ["Aqara", "Thermostat S2 CN", "KTWKQ03ES"],
     "spec": [
-        # BoolConv("power", mi="3.1.85", xiaomi="power_status"),
         ClimateConv("climate", "climate", mi="14.2.85"),
+        BoolConv("power", mi="3.1.85"),
         Converter("current_temp", mi="3.2.85"),
         MapConv("hvac_mode", mi="14.8.85", map={0: "heat", 1: "cool", 15: "off"}),
         MapConv("fan_mode", mi="14.10.85", map={


### PR DESCRIPTION
## 1. fix climate init setup failed problem 

fix TARGET_TEMPERATURE_RANGE to TARGET_TEMPERATURE.
![image](https://github.com/AlexxIT/XiaomiGateway3/assets/32849562/9f06700d-2997-4825-a857-b53a6a321533)

![image](https://github.com/AlexxIT/XiaomiGateway3/assets/32849562/58577967-d28c-40f2-a35a-648d79db85f1)

log:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 752, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1278, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 941, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1062, in _async_write_ha_state
    state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1001, in __async_calculate_state
    attr.update(self.state_attributes or {})
                ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 369, in state_attributes
    hass, self.target_temperature_high, temperature_unit, precision
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/backports/functools.py", line 70, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 449, in target_temperature_high
    return self._attr_target_temperature_high
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 338, in _getter
    return getattr(o, private_attr_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ScdvbHAVC' object has no attribute '__attr_target_temperature_high
```

## 2. support scdvb havc device,
I change the modification method, so it will not affect other devices, only itself.
#1216 
#1217 
![image](https://github.com/AlexxIT/XiaomiGateway3/assets/32849562/df5c2dd3-ac33-44ff-9d82-2475332d5ada)
