### PR TITLE
Add mibeacon2 spec to yeelink.remote.contrl

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1536,6 +1536,10 @@ DEVICES += [{
 }, {
     6473: ["Yeelight", "Double Button", "XMWXKG01YL", "yeelink.remote.contrl"],
     "spec": [
+        # mibeacon2 spec
+        MapConv("action", mi=19980, map={"01": BUTTON_1_SINGLE, "02": BUTTON_2_SINGLE, "03": BUTTON_BOTH_SINGLE}),
+        MapConv("action", mi=19981, map={"01": BUTTON_1_DOUBLE, "02": BUTTON_2_DOUBLE}),
+        MapConv("action", mi=19982, map={"01": BUTTON_1_HOLD, "02": BUTTON_2_HOLD}),
         # miot spec
         BaseConv("battery", "sensor", mi="2.p.1003"),
         BaseConv("action", "sensor"),


### PR DESCRIPTION
The action of `yeelink.remote.contrl` is invalid for me, and it works correctly after add mibeacon2 spec.