### PR TITLE
fix battery configuration for xiaomi.sensor_occupy.03

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1644,7 +1644,7 @@ DEVICES += [{
         BoolConv("occupancy", "binary_sensor", mi="2.p.1078"),#Tested
         BaseConv("illuminance", "sensor", mi="2.p.1005"),#Tested
         # other sensors
-        BaseConv("battery", mi="3.p.1003"),
+        BaseConv("battery", "sensor", mi="3.p.1003"),
 
     ],
 }, {

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1644,7 +1644,7 @@ DEVICES += [{
         BoolConv("occupancy", "binary_sensor", mi="2.p.1078"),#Tested
         BaseConv("illuminance", "sensor", mi="2.p.1005"),#Tested
         # other sensors
-        BaseConv("battery", "sensor", mi="3.p.1003"),
+        BaseConv("battery", "sensor", mi="3.p.1003", entity=ENTITY_LAZY),
 
     ],
 }, {


### PR DESCRIPTION
https://github.com/AlexxIT/XiaomiGateway3/pull/1369#issuecomment-2132630069
>As for the battery, I couldn't test it initially due to the low reporting frequency. I later tried adding "sensor" and tested it, and you seem to be correct.