### PR TITLE
Add support for Xiaomi hoto.light.lamp

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -3288,6 +3288,21 @@ DEVICES += [{
         BoolConv("pilot_switch", "switch", mi="3.p.6", entity=ENTITY_CONFIG),
     ],
 },{
+    # https://home.miot-spec.com/spec/hoto.light.lamp
+    9387: ["Xiaomi", "Multifunctional Camping Lantern", "hoto.light.lamp"],
+    "spec": [
+        BaseConv("light", "light", mi="2.p.1"),
+        BrightnessConv("brightness", mi="2.p.2", max=100),
+        ColorTempKelvin("color_temp", mi="2.p.3", mink=2700, maxk=5000),
+        MathConv("color", "number", mi="2.p.4", min=1, max=16777215),
+        MapConv("mode", "select", mi="2.p.5", map={1: "Auto", 2: "Day", 3: "Color", 4: "Warmth", 5: "Leisure"}),
+        BaseConv("battery", "sensor", mi="3.p.1"), 
+        MapConv("main_ charging_state", "sensor", mi="3.p.2", map={0: "Not Plug", 1: "Plug In"}), 
+        MapConv("sub_ charging_state", "sensor", mi="3.p.3", map={0: "No Equipment", 1: "Charging", 2: "Full", 3: "Inserted Without Charge"}), 
+        BoolConv("delay_switch", "switch", mi="4.p.1"),
+        MathConv("delay_time", "number", mi="4.p.2", min=1, max=60), 
+    ],
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         BaseConv("switch", "switch", mi="2.p.1", entity=ENTITY_LAZY),  # bool


### PR DESCRIPTION
Add support for Xiaomi Mijia Camping Lantern hoto.light.lamp

```
{ 
    # https://home.miot-spec.com/spec/hoto.light.lamp
    9387: ["Xiaomi", "Multifunctional Camping Lantern", "hoto.light.lamp"],
    "spec": [
        BaseConv("light", "light", mi="2.p.1"),
        BrightnessConv("brightness", mi="2.p.2", max=100),
        ColorTempKelvin("color_temp", mi="2.p.3", mink=2700, maxk=5000),
        MathConv("color", "number", mi="2.p.4", min=1, max=16777215),
        MapConv("mode", "select", mi="2.p.5", map={1: "Auto", 2: "Day", 3: "Color", 4: "Warmth", 5: "Leisure"}),
        BaseConv("battery", "sensor", mi="3.p.1"), 
        MapConv("main_ charging_state", "sensor", mi="3.p.2", map={0: "Not Plug", 1: "Plug In"}), 
        MapConv("sub_ charging_state", "sensor", mi="3.p.3", map={0: "No Equipment", 1: "Charging", 2: "Full", 3: "Inserted Without Charge"}), 
        BoolConv("delay_switch", "switch", mi="4.p.1"),
        MathConv("delay_time", "number", mi="4.p.2", min=1, max=60), 
    ],
}, 
```

<img width="1565" alt="hoto.light.lamp" src="https://github.com/AlexxIT/XiaomiGateway3/assets/29325925/88f7fbac-3596-4bab-925b-3d9b01c283eb">
