### PR TITLE
Add `telnet_password` for `ShellE1` and `ShellMGW2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Only for Xiaomi Multimode Gateway 1:
 - **Host** - gateway IP-address, should be fixed on your Wi-Fi router
 - **Token** - gateway Mi Home token, changed only when you add gateway to Mi Home app
 - **Key** - gateway secret key, [read more](https://github.com/AlexxIT/Blog/issues/13)
+- **Telnet Password** - gateway(`Aqara_Hub_E1` or `Mijia_Hub_V2`) telnet password. Password will setup while adding integration(keep field empty if you don't want setup password), or you need change both integration config and password in telnet(`passwd` or `chpasswd`) later.
 - **Add statistic sensors** - [read more](#statistics-table)
 - **Debug logs** - enable different levels of logging ([read more](#debug-mode))
 

--- a/custom_components/xiaomi_gateway3/config_flow.py
+++ b/custom_components/xiaomi_gateway3/config_flow.py
@@ -51,6 +51,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                             vol.Required("host", default=device["localip"]): str,
                             vol.Required("token", default=device["token"]): str,
                             vol.Optional("key"): str,
+                            vol.Optional("telnet_password"): str,
                         }
                     ),
                 )
@@ -121,6 +122,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 vol.Required("host"): str,
                 vol.Required("token"): str,
                 vol.Optional("key"): str,
+                vol.Optional("telnet_password"): str,
             },
             user_input,
         )
@@ -189,6 +191,7 @@ class CloudOptionsandler(OptionsFlow):
                 vol.Required("host"): str,
                 vol.Required("token"): str,
                 vol.Optional("key"): str,
+                vol.Optional("telnet_password"): str,
                 vol.Optional("stats"): vol.In(
                     {
                         False: "Disabled",  # for backward compatibility

--- a/custom_components/xiaomi_gateway3/core/gate/openmiio.py
+++ b/custom_components/xiaomi_gateway3/core/gate/openmiio.py
@@ -83,7 +83,7 @@ class OpenMiioGateway(XGateway):
 
     async def openmiio_restart(self):
         try:
-            async with Session(self.host) as sh:
+            async with Session(self.host, telnet_password = self.options["telnet_password"]) as sh:
                 if await sh.only_one():
                     await self.openmiio_prepare_gateway(sh)
         except Exception as e:

--- a/custom_components/xiaomi_gateway3/core/gate/silabs.py
+++ b/custom_components/xiaomi_gateway3/core/gate/silabs.py
@@ -161,7 +161,7 @@ class SilabsGateway(XGateway):
     async def silabs_process_join(self, data: dict):
         self.debug("silabs_process_join", data=data)
         try:
-            async with Session(self.host) as sh:
+            async with Session(self.host, telnet_password = self.options["telnet_password"]) as sh:
                 # check if model should be prevented from unpairing
                 if self.force_pair or not data["model"].startswith(("lumi.", "ikea.")):
                     self.force_pair = False
@@ -287,7 +287,7 @@ class SilabsGateway(XGateway):
 
     async def silabs_restart(self):
         try:
-            async with Session(self.host) as sh:
+            async with Session(self.host, telnet_password = self.options["telnet_password"]) as sh:
                 # names for all supported gateway models
                 await sh.exec("killall Lumi_Z3GatewayHost_MQTT mZ3GatewayHost_MQTT")
         except Exception as e:

--- a/custom_components/xiaomi_gateway3/core/gateway.py
+++ b/custom_components/xiaomi_gateway3/core/gateway.py
@@ -63,7 +63,7 @@ class MultiGateway(
             return False
         try:
             resp = await core_utils.enable_telnet(
-                self.host, token, self.options.get("key")
+                self.host, token, self.options.get("key"), self.options.get("telnet_password")
             )
             self.debug("enable_telnet", data=resp)
             return resp == "ok"
@@ -73,7 +73,7 @@ class MultiGateway(
 
     async def prepare_gateway(self) -> bool:
         try:
-            async with Session(self.host) as sh:
+            async with Session(self.host, telnet_password = self.options["telnet_password"]) as sh:
                 if not await sh.only_one():
                     self.debug("Connection from a second Hass detected")
                     return False
@@ -167,7 +167,7 @@ class MultiGateway(
     async def telnet_command(self, cmd: str) -> bool | None:
         self.debug("telnet_command", data=cmd)
         try:
-            async with Session(self.host) as sh:
+            async with Session(self.host, telnet_password = self.options["telnet_password"]) as sh:
                 if cmd == "run_ftp":
                     await sh.run_ftp()
                     return True

--- a/custom_components/xiaomi_gateway3/core/shell/base.py
+++ b/custom_components/xiaomi_gateway3/core/shell/base.py
@@ -5,9 +5,10 @@ import aiohttp
 
 
 class ShellBase:
-    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter, telnet_password: str = None):
         self.reader = reader
         self.writer = writer
+        self.telnet_password = telnet_password
 
     async def close(self):
         if not self.writer:

--- a/custom_components/xiaomi_gateway3/core/shell/shell_e1.py
+++ b/custom_components/xiaomi_gateway3/core/shell/shell_e1.py
@@ -9,7 +9,9 @@ class ShellE1(ShellBase):
     async def login(self):
         self.writer.write(b"root\n")
         await asyncio.sleep(0.1)
-        self.writer.write(b"\n")  # empty password
+        if self.telnet_password:
+            self.writer.write(str.encode(self.telnet_password))
+        self.writer.write(b"\n")
 
         coro = self.reader.readuntil(b" # ")
         await asyncio.wait_for(coro, timeout=3)

--- a/custom_components/xiaomi_gateway3/translations/en.json
+++ b/custom_components/xiaomi_gateway3/translations/en.json
@@ -31,7 +31,8 @@
         "data": {
           "host": "Host",
           "token": "Token",
-          "key": "Key"
+          "key": "Key",
+          "telnet_password": "Telnet Password"
         }
       }
     }

--- a/custom_components/xiaomi_gateway3/translations/zh-Hans.json
+++ b/custom_components/xiaomi_gateway3/translations/zh-Hans.json
@@ -30,7 +30,8 @@
         "data": {
           "host": "网关IP",
           "token": "Token",
-          "key": "Key"
+          "key": "Key",
+          "telnet_password": "Telnet密码"
         }
       }
     }

--- a/custom_components/xiaomi_gateway3/translations/zh-Hant.json
+++ b/custom_components/xiaomi_gateway3/translations/zh-Hant.json
@@ -31,7 +31,8 @@
         "data": {
           "host": "網關IP",
           "token": "Token",
-          "key": "Key"
+          "key": "Key",
+          "telnet_password": "Telnet密碼"
         }
       }
     }


### PR DESCRIPTION
Add `telnet_password` in ConfigFlow, only tested on `Mijia_Hub_V2`.
It's not safe to set a empty password for root user, Gateway exposes telnet port in the public network, especially in IPv6 network.

## README.md

**Telnet Password** - gateway(`Aqara_Hub_E1` or `Mijia_Hub_V2`) telnet password. Password will setup while adding integration(keep field empty if you don't want setup password), or you need change both integration config and password in telnet(`passwd` or `chpasswd`) later.

## Config

![image](https://github.com/user-attachments/assets/b005bb3e-2c58-4671-a7ad-a5f1ac639de5)

## Issues 
- #625
- #1304 

## Known issue

If `telnet_password` is configured and not empty, user can not reconfigure `telnet_password` to empty, I'm not familiar with Python, maybe you can fix it. :-)