### PR TITLE
Add support for LifeControl MCLH-08

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/zigbee.py
+++ b/custom_components/xiaomi_gateway3/core/converters/zigbee.py
@@ -386,6 +386,22 @@ class ZTuyaButtonConv(ZConverter):
         except:
             pass
 
+@dataclass
+class ZLifeControlHumidity(ZMathConv):
+    cluster_id = TemperatureMeasurement.cluster_id
+    attr_id = TemperatureMeasurement.AttributeDefs.min_measured_value.id
+    multiply: float = 0.01
+
+@dataclass
+class ZLifeControlECO2(ZMathConv):
+    cluster_id = TemperatureMeasurement.cluster_id
+    attr_id = TemperatureMeasurement.AttributeDefs.max_measured_value.id
+
+@dataclass
+class ZLifeControlVOC(ZMathConv):
+    cluster_id = TemperatureMeasurement.cluster_id
+    attr_id = TemperatureMeasurement.AttributeDefs.tolerance.id
+
 
 # Thanks to zigbee2mqtt:
 # https://github.com/Koenkk/zigbee-herdsman/blob/528b7626f2970ba87a0792920590926105a3cb48/src/zcl/definition/cluster.ts#LL460C32-L460C37

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1318,6 +1318,15 @@ DEVICES += [{
         ZBatteryPercConv("battery", "sensor", multiply=1.0),
     ],
 }, {
+    "VOC_Sensor": ["LifeControl", "Air quality Sensor", "MCLH-08"],
+    "spec": [
+        ZTemperatureConv("temperature", "sensor"),
+        ZLifeControlHumidity("humidity", "sensor"),
+        ZLifeControlECO2("eco_two", "sensor"),
+        ZLifeControlVOC("tvoc", "sensor"),
+        ZBatteryPercConv("battery", "sensor", multiply=1.0),
+    ],
+}, {
     "default": "zigbee",  # default zigbee device
     "spec": [
         ZModelConv("model", "sensor", entity={"category": "diagnostic", "icon": "mdi:information", "lazy": True}),

--- a/custom_components/xiaomi_gateway3/hass/entity_description.py
+++ b/custom_components/xiaomi_gateway3/hass/entity_description.py
@@ -7,6 +7,7 @@ from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import (
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
+    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     MAJOR_VERSION,
     MINOR_VERSION,
@@ -86,6 +87,7 @@ ENTITY_DESCRIPTIONS: dict[str, dict] = {
     "smoke_density": {"icon": "mdi:google-circles-communities", "units": "% obs/ft"},
     "supply": {"icon": "mdi:gauge", "units": PERCENTAGE},
     "tvoc": {"icon": "mdi:cloud", "units": CONCENTRATION_PARTS_PER_BILLION},
+    "eco_two": {"name": "eCO2", "icon": "mdi:molecule-co2", "units": CONCENTRATION_PARTS_PER_MILLION},
     ##
     # stats sensors
     "binary_sensor.gateway": {


### PR DESCRIPTION
Add convertor for device LifeControlAir quality Sensor (MCLH-08).

![изображение](https://github.com/user-attachments/assets/6da25ff0-da1c-42ba-bc68-130bc07c3371)