### PR TITLE
Add support for various devices

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -2896,6 +2896,17 @@ DEVICES += [{
         MapConv("led", "select", mi="4.p.1", map={0: "follow_switch", 1: "opposite_to_switch", 2: "off", 3: "on"})
     ]
 }, {
+    16415: ["GranwinIoT", "Mesh Smart Plug V6", "giot.plug.v6shsm"],
+    "spec": [
+        BaseConv("plug", "switch", mi="2.p.1"),
+        MapConv("power_on_state", "select", mi="2.p.5", map={0: "off", 1: "on", 2: "previous"}),
+        # Inching mode
+        BoolConv("inching_mode", "switch", mi="2.p.4"),
+        MapConv("inching_state", "select", mi="6.p.1", map={False: "off", True: "on"}),
+        MathConv("inching_time", "number", mi="6.p.2", multiply=0.5, min=1, max=7200, step=1, round=1),
+        MapConv("led", "select", mi="6.p.3", map={0: "follow_switch", 1: "opposite_to_switch", 2: "off", 3: "on"})
+    ]
+}, {
     # A third party module widely used in small brand wall switches
     6514: [None, "Mesh Single Wall Switch (with N)", "babai.switch.201m"],
     # A third party module widely used in small brand wall switches

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1695,11 +1695,51 @@ DEVICES += [{
         MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD, 2: BUTTON_2_HOLD, 3: BUTTON_3_HOLD, 4: BUTTON_4_HOLD, 5: "button_5_hold", 6: "button_6_hold", 7: "button_7_hold", 8: "button_8_hold"}),
     ]
 }, {
-    16186: ["Smartfrog", "Wireless Button", "giot.remote.v58kwm"],
+    16191: ["GranwinIoT", "V5 One Key Switch (BLE)", "giot.remote.v51kwm"],
+    "spec": [
+        BaseConv("action", "sensor"),
+        MapConv("action", mi="2.e.1012.p.1", map={1: BUTTON_1_SINGLE}),
+        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE}),
+        MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD}),
+    ]
+}, {
+    16180: ["GranwinIoT", "V5 Two Key Switch (BLE)", "giot.remote.v52kwm"],
+    "spec": [
+        BaseConv("action", "sensor"),
+        MapConv("action", mi="2.e.1012.p.1", map={1: BUTTON_1_SINGLE, 2: BUTTON_2_SINGLE}),
+        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE, 2: BUTTON_2_DOUBLE}),
+        MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD, 2: BUTTON_2_HOLD}),
+    ]
+}, {
+    16181: ["GranwinIoT", "V5 Three Key Switch (BLE)", "giot.remote.v53kwm"],
+    "spec": [
+        BaseConv("action", "sensor"),
+        MapConv("action", mi="2.e.1012.p.1", map={1: BUTTON_1_SINGLE, 2: BUTTON_2_SINGLE, 3: BUTTON_3_SINGLE}),
+        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE, 2: BUTTON_2_DOUBLE, 3: BUTTON_3_DOUBLE}),
+        MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD, 2: BUTTON_2_HOLD, 3: BUTTON_3_HOLD}),
+    ]
+}, {
+    16182: ["GranwinIoT", "V5 Four Key Switch (BLE)", "giot.remote.v54kwm"],
+    "spec": [
+        BaseConv("action", "sensor"),
+        MapConv("action", mi="2.e.1012.p.1", map={1: BUTTON_1_SINGLE, 2: BUTTON_2_SINGLE, 3: BUTTON_3_SINGLE, 4: BUTTON_4_SINGLE}),
+        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE, 2: BUTTON_2_DOUBLE, 3: BUTTON_3_DOUBLE, 4: BUTTON_4_DOUBLE}),
+        MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD, 2: BUTTON_2_HOLD, 3: BUTTON_3_HOLD, 4: BUTTON_4_HOLD}),
+    ]
+}, {
+    16184: ["GranwinIoT", "V5 Six Key Switch (BLE)", "giot.remote.v56kwm"],
+    "spec": [
+        BaseConv("action", "sensor"),
+        MapConv("action", mi="2.e.1012.p.1", map={1: BUTTON_1_SINGLE, 2: BUTTON_2_SINGLE, 3: BUTTON_3_SINGLE, 4: BUTTON_4_SINGLE, 5: "button_5_single", 6: "button_6_single"}),
+        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE, 2: BUTTON_2_DOUBLE, 3: BUTTON_3_DOUBLE, 4: BUTTON_4_DOUBLE, 5: "button_5_double", 6: "button_6_double"}),
+        MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD, 2: BUTTON_2_HOLD, 3: BUTTON_3_HOLD, 4: BUTTON_4_HOLD, 5: "button_5_hold", 6: "button_6_hold"}),
+    ]
+}, {
+    16186: ["GranwinIoT", "V5 Eight Key Switch (BLE)", "giot.remote.v58kwm"],
     "spec": [
         BaseConv("action", "sensor"),
         MapConv("action", mi="2.e.1012.p.1", map={1: BUTTON_1_SINGLE, 2: BUTTON_2_SINGLE, 3: BUTTON_3_SINGLE, 4: BUTTON_4_SINGLE, 5: "button_5_single", 6: "button_6_single", 7: "button_7_single", 8: "button_8_single"}),
-        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE, 2: BUTTON_2_DOUBLE, 3: BUTTON_3_DOUBLE, 4: "button_4_double", 5: "button_5_double", 6: "button_6_double", 7: "button_7_double", 8: "button_8_double"}),
+        MapConv("action", mi="2.e.1013.p.1", map={1: BUTTON_1_DOUBLE, 2: BUTTON_2_DOUBLE, 3: BUTTON_3_DOUBLE, 4: BUTTON_4_DOUBLE, 5: "button_5_double", 6: "button_6_double", 7: "button_7_double", 8: "button_8_double"}),
         MapConv("action", mi="2.e.1014.p.1", map={1: BUTTON_1_HOLD, 2: BUTTON_2_HOLD, 3: BUTTON_3_HOLD, 4: BUTTON_4_HOLD, 5: "button_5_hold", 6: "button_6_hold", 7: "button_7_hold", 8: "button_8_hold"}),
     ]
 }, {

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -3326,6 +3326,14 @@ DEVICES += [{
         MapConv("mode", "select", mi="2.p.5", map={0: "default", 1: "double", 2: "left", 3: "right"}),
     ],
 }, {
+    17659: [None, "Smart Curtain Motor (Mesh)", "zjdh.curtain.xj002"],
+    "spec": [
+        MapConv("motor", "cover", mi="2.p.1", map={0: "stop", 1: "open", 2: "close"}),
+        BaseConv("target_position", mi="2.p.3"),
+        CurtainPosConv("position", mi="2.p.2"),
+        BaseConv("motor_reverse", "switch", mi="2.p.5")
+    ],
+}, {
     13140: ["GranwinIoT", "Three-Button Switch (Mesh) V5", "giot.switch.v53ksm"],
     "spec": [
         BaseConv("channel_1", "switch", mi="2.p.1"),


### PR DESCRIPTION
Hi. This PR includes:

- Add support for giot.plug.v6shsm
- Add support for zjdh.curtain.xj002
- Add support for series of GranwinIoT wireless switches (giot.remote.v51kwm, giot.remote.v52kwm, giot.remote.v53kwm, giot.remote.v54kwm and giot.remote.v56kwm)
- Change string to enum (BUTTON_4_DOUBLE) for giot.remote.v58kwm