### PR TITLE
Add initial support for Sonoff S60ZBTPF

### DIFF
--- a/custom_components/xiaomi_gateway3/core/converters/zigbee.py
+++ b/custom_components/xiaomi_gateway3/core/converters/zigbee.py
@@ -216,7 +216,8 @@ class ZTransitionConv(BaseConv):
         payload[self.attr] = value
 
 
-class ZVoltageConv(ZConverter):
+@dataclass
+class ZVoltageConv(ZMathConv):
     cluster_id = ElectricalMeasurement.cluster_id
     attr_id = ElectricalMeasurement.AttributeDefs.rms_voltage.id
 

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1260,6 +1260,19 @@ DEVICES += [{
         ZBatteryPercConv("battery", "sensor", report="1h 12h 0", multiply=0.5),
     ],
 }, {
+    "S60ZBTPF": ["Sonoff", "Smart Plug", "S60ZBTPF"],
+    # Initial support for S60ZBTPF
+    # Energy-related data is only updated when the switch is turned on — possibly a device firmware-related issue
+    # This device does not provide a total energy sensor; only "yesterday", "today", and "month" energy values are available (not yet implemented)
+    # Many other features are also not implemented
+    "spec": [
+        ZOnOffConv("plug", "switch", report="0s 5m 0"),
+        ZCurrentConv("current", "sensor", report="12s 57m 10"),
+        ZPowerConv("power", "sensor", report="10s 10m 3"),
+        ZVoltageConv("voltage", "sensor", report="11s 55m 10", multiply=0.01), # need changes in ZVoltageConv class
+        ZPowerOnConv("power_on_state", "select")
+    ],
+}, {
     "SML001": ["Philips", "Hue motion sensor", "9290012607"],
     "support": 4,  # @AlexxIT TODO: sensitivity, led
     "spec": [


### PR DESCRIPTION
Add initial support for Sonoff S60ZBTPF. This device does not provide a total energy sensor; only "yesterday", "today", and "month" energy values are available (not implemented by this PR).

⚠️ **Please review carefully before merging**, as ZVoltageConv class has been modified — a multiply = 0.01 factor is required for correct voltage scaling.