### PR TITLE
Fix mijia.light.group3 Brightness (1-100%), Color Temp (1700K-7000K);…

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -5090,11 +5090,18 @@ DEVICES += [{
 DEVICES += [{
     1047: ["Yeelight", "Classic Group", "yeelink.light.dn2grp"],
     1054: ["Yeelight", "Mesh Group", "yeelink.light.mb1grp"],
-    68286: ["Xiaomi", "Light Group", "mijia.light.group3"],
-    "spec": [
+     "spec": [
         BaseConv("light", "light", mi="2.p.1", entity={"icon": "mdi:lightbulb-group"}),  # bool
         BrightnessConv("brightness", mi="2.p.2", max=65535),  # uint16
         ColorTempKelvin("color_temp", mi="2.p.3"),  # uint32, 2700..6500
+    ]
+}, {    
+    68286: ["Xiaomi", "Light Group", "mijia.light.group3"],
+    "spec": [
+        BaseConv("light", "light", mi="2.p.1", entity={"icon": "mdi:lightbulb-group"}),  # bool
+        BrightnessConv("brightness", mi="2.p.2", max=100),  # uint8
+        ColorTempKelvin("color_temp", mi="2.p.3", mink=1700, maxk=7000),  # uint32, 1700..7000
+        MapConv("mode", mi="2.p.6", map={3: "tv",4: "hospitality", 5: "night",6: "computer"}, entity={"icon": "mdi:theme-light-dark"})
     ]
 }, {
     71017: ["Xiaomi", "Curtain Group", "lumi.curtain.hmcn04"],


### PR DESCRIPTION
… Add Scene Mode

Based on the latest specification #https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:light:0000A001:mijia-group3:3:0000C802, the following fixes have been made: ﻿Brightness Range Adjustment: Changed max=65535 to max=100, as the JSON explicitly states the brightness range is 1-100 (percentage). Color Temperature Range Adjustment: Added min=1700 and max=7000 parameters to match the color temperature range (1700-7000K) specified in the JSON. Added Mode Property: Implemented MapConv to translate numerical mode values into human-readable strings: 3 → "tv" (TV Mode)
4 → "hospitality" (Hospitality Mode)
5 → "night" (Night Light Mode)
6 → "computer" (Computer Mode)
Added Icons: Included appropriate icons for the Mode property. These modifications ensure the code now more accurately reflects the device's functionality and parameter ranges as defined in the specification.