### PR TITLE
Add basic support for Mean Well Smart Chromatic Controller (ftd.light.nomain)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -5087,7 +5087,6 @@ DEVICES += [{
         ColorTempKelvin("color_temp", mi="2.p.3", mink=3000, maxk=6500),
         BaseConv("flex_switch", "switch", mi="2.p.12", entity=ENTITY_CONFIG), 
         MapConv("mode","select",mi="2.p.13", map={0: "None", 1: "Day", 2: "Night", 3: "Warmth", 4: "TV", 5: "Reading", 6: "Computer", 7: "Sleep", 8: "Wakeup"}),
-        BaseConv("default_onoff_state",mi="4.p.29", entity=ENTITY_CONFIG),
     ],
 }, {
     "default": "mesh",  # default Mesh device


### PR DESCRIPTION
This PR adds basic support for ftd.light.nomain
The product does not have official english name on xiaomi's site so I used the english name on the box

Supported functions:
- Power
- Brightness
- Color Temp
- Invoking Modes
- Flex switch

All the above features have been tested on my own hardware