### PR TITLE
Add support Xiaomi Label printer (xiaomi.printer.label)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1489,18 +1489,17 @@ DEVICES += [{
         BLEToothbrush("toothbrush", mi=16),
     ],
 }, { 
-    # MIOT https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:printer:0000A060:xiaomi-label:1
-    13566: ["Xiaomi", "Label printer", "MJBQDYJ1-WC","xiaomi.printer.label"], 
-    "spec": [
-        MapConv("printer_state", "sensor", mi="2.p.1", map={ 0: "standby", 1: "working", 2: "complete", 3: "suspend"}),
-        BaseConv("copies", "sensor", mi="2.p.3"),
-        MapConv("paper_lack", "binary_sensor", mi="2.p.4", map={ True: "True", False: "False"}),
-        MapConv("cover_open", "binary_sensor", mi="2.p.5", map={ True: "True", False: "False"}),
-        MapConv("fault", "sensor", mi="2.p.6", map={ 0: "normal",1: "paper_lack", 2: "cover_open", 3: "overheat"}),
-        BaseConv("battery", "sensor", mi="3.p.1"),
-        MathConv("battery_low", "binary_sensor", mi="3.p.1", multiply=0.01, min=0, max=0.2 )
-    ],
-    "ttl": 600  
+   # MIOT https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:printer:0000A060:xiaomi-label:1
+   13566: ["Xiaomi", "Label printer", "MJBQDYJ1-WC", "xiaomi.printer.label"], 
+   "spec": [
+       MapConv("printer_state", "sensor", mi="2.p.1", map={0: "standby", 1: "working", 2: "complete", 3: "suspend"}),
+       BaseConv("copies", "sensor", mi="2.p.3"),
+       MapConv("paper_lack", "binary_sensor", mi="2.p.4", map={1: True, 0: False}),
+       MapConv("cover_open", "binary_sensor", mi="2.p.5", map={1: True, 0: False}),
+       MapConv("fault", "sensor", mi="2.p.6", map={0: "normal", 1: "paper_lack", 2: "cover_open", 3: "overheat"}),
+       BaseConv("battery", "sensor", mi="3.p.1"),
+],
+    "ttl": "10m"  
 }, {
     1249: ["Xiaomi", "Magic Cube", "XMMF01JQD", "jiqid.robot.cube"],  # 4097
     "spec": [

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1488,6 +1488,19 @@ DEVICES += [{
         BLEByteConv("supply", "sensor", mi=4115),  # uint8, Remaining percentage, range 0~100
         BLEToothbrush("toothbrush", mi=16),
     ],
+}, { 
+    # MIOT https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:printer:0000A060:xiaomi-label:1
+    13566: ["Xiaomi", "Label printer", "MJBQDYJ1-WC","xiaomi.printer.label"], 
+    "spec": [
+        MapConv("printer_state", "sensor", mi="2.p.1", map={ 0: "standby", 1: "working", 2: "complete", 3: "suspend"}),
+        BaseConv("copies", "sensor", mi="2.p.3"),
+        MapConv("paper_lack", "binary_sensor", mi="2.p.4", map={ True: "True", False: "False"}),
+        MapConv("cover_open", "binary_sensor", mi="2.p.5", map={ True: "True", False: "False"}),
+        MapConv("fault", "sensor", mi="2.p.6", map={ 0: "normal",1: "paper_lack", 2: "cover_open", 3: "overheat"}),
+        BaseConv("battery", "sensor", mi="3.p.1"),
+        MathConv("battery_low", "binary_sensor", mi="3.p.1", multiply=0.01, min=0, max=0.2 )
+    ],
+    "ttl": 600  
 }, {
     1249: ["Xiaomi", "Magic Cube", "XMMF01JQD", "jiqid.robot.cube"],  # 4097
     "spec": [


### PR DESCRIPTION
This code defines a device driver configuration that: Standardizes state data for Xiaomi Label Printers (errors, battery, paper status). Converts low-level hardware register values into user-friendly semantic states (e.g., working, overheat). Provides device integration specifications for Home Assistant , enabling status monitoring and automation control.