### PR TITLE
Fix _get_notification_url to support new Xiaomi auth URL

### DIFF
--- a/custom_components/xiaomi_gateway3/core/xiaomi_cloud.py
+++ b/custom_components/xiaomi_gateway3/core/xiaomi_cloud.py
@@ -185,8 +185,8 @@ class MiCloud:
         return {"ok": True, "token": f"{data['userId']}:{data['passToken']}"}
 
     async def _get_notification_url(self, notification_url: str) -> AuthResult:
-        assert "/identity/authStart" in notification_url, notification_url
-        notification_url = notification_url.replace("authStart", "list")
+        assert "fe/service/identity/authStart" in notification_url, notification_url
+        notification_url = notification_url.replace("fe/service/identity/authStart", "identity/list")
 
         r = await self.session.get(notification_url)
         res1 = parse_auth_response(await r.read())

--- a/custom_components/xiaomi_gateway3/core/xiaomi_cloud.py
+++ b/custom_components/xiaomi_gateway3/core/xiaomi_cloud.py
@@ -185,8 +185,10 @@ class MiCloud:
         return {"ok": True, "token": f"{data['userId']}:{data['passToken']}"}
 
     async def _get_notification_url(self, notification_url: str) -> AuthResult:
-        assert "fe/service/identity/authStart" in notification_url, notification_url
-        notification_url = notification_url.replace("fe/service/identity/authStart", "identity/list")
+        assert "/fe/service/identity/authStart" in notification_url, notification_url
+        notification_url = notification_url.replace(
+            "/fe/service/identity/authStart", "/identity/list"
+        )
 
         r = await self.session.get(notification_url)
         res1 = parse_auth_response(await r.read())


### PR DESCRIPTION
This patch updates the `_get_notification_url` function in Xiaomi Gateway 3 
to handle Xiaomi's updated authentication URL ("fe/service/identity/authStart"). 

Inspired by a similar change in Xiaomi MIoT integration (see commit: 
https://github.com/al-one/hass-xiaomi-miot/commit/5d8e314f6b90a8a251b18e0298a4172f2990bb6e), 
this PR adapts the approach for Xiaomi Gateway 3.

Tested locally: with this patch, the login flow proceeds further and prompts 
for the verification code. Full end-to-end testing with actual Xiaomi Gateway 
devices has not been performed, as I do not have a gateway available.

This change should allow users to proceed with login on Xiaomi Cloud accounts 
that use the new URL format.
