### PR TITLE
Add support for Linptech Human Presence Sensor ES5

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1769,6 +1769,17 @@ DEVICES += [{
         BoolConv("led", "binary_sensor", mi="3.p.1"),  # bool, config
     ],
 }, {
+    # https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:occupancy-sensor:0000A0BF:linp-es4b:1
+    28377: ["Linptech", "Human Presence Sensor ES5(Top Mounted)", "ES5DB", "linp.sensor_occupy.es4b"],
+    "spec": [
+        BoolConv("occupancy", "binary_sensor", mi="2.p.1078"),
+        BaseConv("illuminance", "sensor", mi="2.p.1005"),
+        BaseConv("has_someone_duration", "sensor", mi="2.p.1081", entity={"units": UNIT_MINUTES, "icon": "mdi:timer"}),
+        MathConv("no_one_duration", "sensor", mi="2.p.1082", min=1, max=120, entity={"units": UNIT_MINUTES, "icon": "mdi:timer-off"}),
+        MapConv("no_one_duration", mi="2.p.1078", map={1: 0}),
+        MapConv("has_someone_duration", mi="2.p.1078", map={0: 0}),
+    ],        
+}, {
     8613: ["H+", "Double Wall Switch", "huca.switch.dh2"],
     "spec": [
         BaseConv("channel_1", "switch", mi="2.p.1"),


### PR DESCRIPTION
This code defines how the raw MiOT data from the Linptech ES5DB human presence sensor is converted into intuitive and usable sensor entities in Home Assistant, including: occupancy status (someone present or not), illuminance level, and durations of "someone present" and "no one present." It also implements state-based logic to reset the duration values accurately when the occupancy status changes.