### PR TITLE
Linp Smart Switch T1 Model Dual Button Recognition Fix

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -3413,7 +3413,7 @@ DEVICES += [{
         MathConv("brightness_orange", "number", mi="10.p.4", min=0, max=100, entity=ENTITY_CONFIG),
     ],
 }, {
-    23309: ["Linptech", "Double Wall Switch T1", "linp.switch.t2dbw2"],
+    23473: ["Linptech", "Double Wall Switch T1", "linp.switch.t2dbw2"],
     "spec": [
         BaseConv("switch_1", "switch", mi="2.p.1"),
         BaseConv("switch_2", "switch", mi="3.p.1"),


### PR DESCRIPTION
I have both the double and triple smart switches from Linp. The triple switch is recognized correctly, but the double switch has an identification issue. The official configuration file lists it as 23309, but the actual model is 23473. After changing it to 23473, it can be recognized properly.