### PR TITLE
Fix the error "does not generate unique IDs" for Xiaomi Temperature and Humidity Sensor 3 #1676

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1714,10 +1714,6 @@ DEVICES += [{
         BLEFloatConv("temperature", "sensor", mi=19457, round=1),
         BLEByteConv("humidity", "sensor", mi=19458),
         BLEByteConv("battery", "sensor", mi=18435, entity=ENTITY_LAZY),
-        # MIoT spec
-        BaseConv("temperature", "sensor", mi="2.p.1001"),
-        BaseConv("humidity", "sensor", mi="2.p.1002"),
-        BaseConv("battery", "sensor", mi="3.p.1003"),
     ],       
 }, {
     10987: ["Linptech", "Motion Sensor 2", "HS1BB", "linp.motion.hs1bb1"],

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1711,9 +1711,13 @@ DEVICES += [{
     21941: ["Xiaomi", "TH Sensor 3 Mini", "MJWSD06MMC", "xiaomi.sensor_ht.mini"],
     "spec": [
         # MiBeacon2 spec 
-        BLEFloatConv("temperature", "sensor", mi=19457, round=1),
-        BLEByteConv("humidity", "sensor", mi=19458),
-        BLEByteConv("battery", "sensor", mi=18435, entity=ENTITY_LAZY),
+        BLEFloatConv("temperature", mi=19457, round=1),
+        BLEByteConv("humidity", mi=19458),
+        BLEByteConv("battery", mi=18435, entity=ENTITY_LAZY),
+        # MIoT spec
+        BaseConv("temperature", "sensor", mi="2.p.1001"),
+        BaseConv("humidity", "sensor", mi="2.p.1002"),
+        BaseConv("battery", "sensor", mi="3.p.1003"),
     ],       
 }, {
     10987: ["Linptech", "Motion Sensor 2", "HS1BB", "linp.motion.hs1bb1"],


### PR DESCRIPTION
Fix the 'does not generate unique IDs' error. Xiaomi TH Sensor 3 Mini (MJWSD06MMC) typically only reports data via Bluetooth broadcast (MiBeacon) and does not support the local area network MIoT protocol (it has no WiFi module). Therefore: Do not define both BLE and MIoT converters simultaneously; only retain the MiBeacon (BLE) part.