### PR TITLE
Add support for Chuanxiang Magnetic Wall Charging Socket zjcx.plug.qcsw02

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -5317,6 +5317,15 @@ DEVICES += [{
         MapConv("mode","select",mi="2.p.13", map={0: "None", 1: "Day", 2: "Night", 3: "Warmth", 4: "TV", 5: "Reading", 6: "Computer", 7: "Sleep", 8: "Wakeup"}),
     ],
 }, {
+    # https://home.miot-spec.com/spec/zjcx.plug.qcsw02
+     25140: ["Chuanxiang", "Magnetic Wall Charging Socket", "zjcx.plug.qcsw02"],
+    "spec": [
+        BaseConv("switch", "switch", mi="2.p.1"),
+        BaseConv("indicator_light", "switch", mi="5.p.1"),
+        BaseConv("magnetic_state", "binary_sensor", mi="6.p.1"),  # Magnetic State
+        MapConv("power_on_state", "select", mi="2.p.5", map={0: "memory", 1: "on", 2: "off"}),
+    ]
+}, {
     "default": "mesh",  # default Mesh device
     "spec": [
         BaseConv("switch", "switch", mi="2.p.1", entity=ENTITY_LAZY),  # bool

--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -5318,13 +5318,13 @@ DEVICES += [{
     ],
 }, {
     # https://home.miot-spec.com/spec/zjcx.plug.qcsw02
-     25140: ["Chuanxiang", "Magnetic Wall Charging Socket", "zjcx.plug.qcsw02"],
+    25140: ["Chuanxiang", "Magnetic Wall Charging Socket", "zjcx.plug.qcsw02"],
     "spec": [
         BaseConv("switch", "switch", mi="2.p.1"),
-        BaseConv("indicator_light", "switch", mi="5.p.1"),
+        BaseConv("led", "switch", mi="5.p.1"),
         BaseConv("magnetic_state", "binary_sensor", mi="6.p.1"),  # Magnetic State
         MapConv("power_on_state", "select", mi="2.p.5", map={0: "memory", 1: "on", 2: "off"}),
-    ]
+    ],
 }, {
     "default": "mesh",  # default Mesh device
     "spec": [


### PR DESCRIPTION
### Add support for zjcx-qcsw02 magnetic wall outlet

This PR adds MIOT support for `zjcx.plug.qcsw02` magnetic wall outlet.

Supported features:
- Main power switch
- Default power-on state (memory / on / off)
- Indicator light switch
- Magnetic state exposed as binary_sensor (opening)
- Remote control management switches

Notes:
- Magnetic state is reported by device when status changes
- No write-only or command-only MIOT properties are exposed as entities
