### PR TITLE
Add MJWSD05MMC international variant (xiaomi.sensor_ht.o3, pid 19527)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1707,6 +1707,17 @@ DEVICES += [{
         BaseConv("battery", mi="2.p.1003"),
     ]
 }, {
+    # https://home.miot-spec.com/s/xiaomi.sensor_ht.o3 — international/Malaysian variant of MJWSD05MMC
+    # Uses MiBeacon v1 EIDs (18433/18434) for temp/humidity, eid 19459 for battery
+    # Different from miaomiaoce.sensor_ht.t9 (pid 10290) which uses MiBeacon v2 EIDs
+    19527: ["Xiaomi", "TH Sensor O3", "MJWSD05MMC", "xiaomi.sensor_ht.o3"],
+    "spec": [
+        # mibeacon spec
+        BLEFloatConv("temperature", "sensor", mi=18433, round=1),  # float
+        BLEByteConv("humidity", "sensor", mi=18434),  # uint8
+        BLEByteConv("battery", "sensor", mi=19459, entity=ENTITY_LAZY),  # uint8
+    ]
+}, {
     # https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:temperature-humidity-sensor:0000A00A:xiaomi-mini:1:0000D063
     21941: ["Xiaomi", "TH Sensor 3 Mini", "MJWSD06MMC", "xiaomi.sensor_ht.mini"],
     "spec": [


### PR DESCRIPTION
## Summary

This adds support for the international/Malaysian variant of the Xiaomi Smart Temperature & Humidity Monitor (MJWSD05MMC).

The model name on the box is identical to the existing pid 10290 (`miaomiaoce.sensor_ht.t9`, Chinese version), but the device internally identifies as a different product (`xiaomi.sensor_ht.o3`, pid 19527) and uses a different MiBeacon protocol version for telemetry:

| Property | pid 10290 (Chinese, sensor_ht.t9) | pid 19527 (International, sensor_ht.o3) |
|---|---|---|
| Temperature EID | 19457 (MiBeacon v2) | **18433** (MiBeacon v1) |
| Humidity EID | 19458 (MiBeacon v2) | **18434** (MiBeacon v1) |
| Battery EID | 18435 (MiBeacon v2) | **19459** |

## Testing

Tested on real hardware:
- Device: MJWSD05MMC purchased in Malaysia, firmware 2.0.0_0005
- Gateway: MGL03 (V5R022C10S110, openmiio 1.2.1)
- Confirmed via gateway `_sync.ble_query_dev` response which returned `pdid: 19527` and an `upRule` listing exactly the EIDs added in the spec
- Temperature, humidity, and battery all read correct values matching device LCD display

## Notes

- spec is BLE-only (no MIoT cloud spec — Xiaomi did not publish a miot-spec for the international variant per https://home.miot-spec.com/s/xiaomi.sensor_ht.o3)
- Battery uses `ENTITY_LAZY` since gateway only forwards battery events on schedule (`upRule.intvl=600`), so the entity appears after first scheduled event rather than on device discovery