### PR TITLE
Add MJWSD05MMC variant with pdid 19527

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -1707,6 +1707,15 @@ DEVICES += [{
         BaseConv("battery", mi="2.p.1003"),
     ]
 }, {
+    # MJWSD05MMC variant with pdid 19527, uses different BLE eids than pdid 10290
+    19527: ["Xiaomi", "TH Sensor 3", "MJWSD05MMC", "miaomiaoce.sensor_ht.t9"],
+    "spec": [
+        # mibeacon2 spec, confirmed via gateway BLE event capture
+        BLEFloatConv("temperature", "sensor", mi=18433, round=1),  # float
+        BLEByteConv("humidity", "sensor", mi=18434),  # uint8
+        BLEByteConv("battery", "sensor", mi=18435, entity=ENTITY_LAZY),  # uint8
+    ],
+}, {
     # https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:temperature-humidity-sensor:0000A00A:xiaomi-mini:1:0000D063
     21941: ["Xiaomi", "TH Sensor 3 Mini", "MJWSD06MMC", "xiaomi.sensor_ht.mini"],
     "spec": [


### PR DESCRIPTION
## Add MJWSD05MMC variant with pdid 19527

I have a Xiaomi Smart Temperature and Humidity Monitor 3 (MJWSD05MMC, bought in the EU) that registers with **pdid 19527** instead of the known 10290. With the current device database it gets no entities because 19527 is missing, and its BLE events use different eids than the `miaomiaoce.sensor_ht.t9` spec (19457/19458).

### Captured BLE events (via Multimode Gateway ZNDMWG02LM, `miio/report`)

```
{"dev":{"did":"blt.4.xxx","mac":"A4:C1:38:A3:1E:97","pdid":19527},"evt":[{"eid":18433,"edata":"6666d641"}]}
{"dev":{"did":"blt.4.xxx","mac":"A4:C1:38:A3:1E:97","pdid":19527},"evt":[{"eid":18434,"edata":"2b"}]}
{"dev":{"did":"blt.4.xxx","mac":"A4:C1:38:A3:1E:97","pdid":19527},"evt":[{"eid":18433,"edata":"6666ce41"}]}
{"dev":{"did":"blt.4.xxx","mac":"A4:C1:38:A3:1E:97","pdid":19527},"evt":[{"eid":18434,"edata":"2c"}]}
```

- eid **18433** = temperature, little-endian float (`6666d641` → 26.8 °C, `6666ce41` → 25.8 °C — matches the device display)
- eid **18434** = humidity, uint8 (`2b` → 43 %, `2c` → 44 % — matches the display)
- battery assumed on the family-standard eid 18435 (uint8)

### Change

New device block mapping pdid 19527 to these eids. Tested locally on 2026-07-05 (HA 2026.7.x, Multimode Gateway ZNDMWG02LM): temperature and humidity entities are created and update correctly with values matching the device display. Battery eid 18435 is assumed from the sibling specs (marked ENTITY_LAZY; no battery event captured yet during the test window).

Device sw_version reported by cloud: 2.0.0_0005.
