### PR TITLE
Add support for giot.plug.v7icm (Gra Smart Controller V7 Mesh)

### DIFF
--- a/custom_components/xiaomi_gateway3/core/devices.py
+++ b/custom_components/xiaomi_gateway3/core/devices.py
@@ -4365,6 +4365,11 @@ DEVICES += [{
         MapConv("right_switch_mode", "select", mi="3.p.2", map={0: "normal_switch", 1: "wireless_switch", 2: "smart_switch", 3: "button_switch"}),
     ]
 }, {
+    23928: ["GranchiploT", "Gra Smart Controller V7 (Mesh)", "giot.plug.v7icm"],
+    "spec": [
+        BaseConv("switch", "switch", mi="2.p.1"),
+    ]
+}, {
     # https://github.com/AlexxIT/XiaomiGateway3/issues/1063
     10371: ["PTX", "Mesh Multifunction Wireless Switch", "PTX-AK3-QMIMB", "090615.remote.mlsw0a"],
     "spec": [


### PR DESCRIPTION
## Description

This PR adds support for the **Gra Smart Controller V7 (Mesh)** device (model: `giot.plug.v7icm`, pdid: `23928`), manufactured by GranchiploT.

The device is a BLE Mesh outlet/switch that supports:
- On/Off switch control

## Changes

- Added device entry to `devices.py`:
  - `pdid`: `23928`
  - `model`: `giot.plug.v7icm`
  - `brand`: `GranchiploT`
  - `name`: `Gra Smart Controller V7 (Mesh)`
- Converter: `BaseConv("switch", "switch", mi="2.p.1")` - controls the main switch via property `#2.p.1` (on/off)

## Testing

- Device discovered automatically via Xiaomi Gateway 3 integration
- Switch control works correctly (on/off)
- State sync works as expected
- Tested with Xiaomi Multimode Gateway 2

## Related

- MIoT spec: https://home.miot-spec.com/spec/giot.plug.v7icm
- Device info: pdid `23928`, model `giot.plug.v7icm`, BLE Mesh protocol

https://home.miot-spec.com/p/giot.plug.v7icm