### PR TITLE
Fix critical crashes, multi-account concurrency issues, and async race conditions across Cloud, Entity, and Gateway modules

### DIFF
--- a/custom_components/xiaomi_gateway3/core/gateway.py
+++ b/custom_components/xiaomi_gateway3/core/gateway.py
@@ -12,7 +12,6 @@ from .gate.openmiio import OpenMiioGateway
 from .gate.silabs import SilabsGateway
 from .shell.session import Session
 
-
 class MultiGateway(
     BLEGateway,
     LumiGateway,
@@ -25,9 +24,7 @@ class MultiGateway(
     main_task: asyncio.Task | None = None
 
     def __init__(self, *args, **kwargs):
-        # Call all parent __init__ methods (handled automatically by MRO)
         super().__init__(*args, **kwargs)
-        # Initialize instance flag to prevent duplicate listener registration
         self._listeners_added = False
 
     def start(self):
@@ -44,13 +41,11 @@ class MultiGateway(
         self.main_task = None
         task.cancel()
         try:
-            # Wait for the task to finish gracefully, with a 5-second timeout
             await asyncio.wait_for(task, timeout=5.0)
         except asyncio.CancelledError:
-            pass  # Expected cancellation
+            pass
         except asyncio.TimeoutError:
             self.warning("Main task did not stop within 5 seconds, forcing cancellation.")
-            # Force cancel again and wait a short time
             task.cancel()
             try:
                 await asyncio.wait_for(task, timeout=1.0)
@@ -64,31 +59,25 @@ class MultiGateway(
     async def run_forever(self):
         while True:
             try:
-                # Check if telnet port is OK
                 if not await core_utils.check_port(self.host, 23):
                     if not await self.enable_telnet():
                         await asyncio.sleep(30)
                         continue
-                
                 if not await self.prepare_gateway():
                     await asyncio.sleep(60)
                     continue
                 
-                # Handle MQTT messages, catch exceptions and cooldown before retrying
                 try:
                     await self.handle_mqtt_messages()
                 except asyncio.CancelledError:
-                    raise  # Propagate cancellation signal to stop the task
+                    raise
                 except Exception as e:
                     self.warning(f"MQTT handler crashed, reconnecting in 10s: {e}", exc_info=e)
-                    await asyncio.sleep(10)  # Cooldown to prevent busy loop
-                    
+                    await asyncio.sleep(10)
             except asyncio.CancelledError:
-                # Ensure the outer loop also responds to cancellation
                 self.debug("run_forever cancelled, exiting")
                 raise
             except Exception as e:
-                # Catch unexpected outer exceptions, log them, and restart the loop
                 self.error(f"Unexpected error in run_forever loop: {e}", exc_info=True)
                 await asyncio.sleep(10)
 
@@ -96,11 +85,9 @@ class MultiGateway(
         """Enable telnet with miio protocol."""
         if not (token := self.options.get("token")):
             return False
-        
         key = self.options.get("key")
         if key is None:
             self.debug("No key provided, assuming it's not required for telnet enable")
-            
         try:
             resp = await core_utils.enable_telnet(self.host, token, key)
             self.debug("enable_telnet", data=resp)
@@ -128,14 +115,12 @@ class MultiGateway(
                     "lumi.gateway.mgl001",
                 )
                 support_matter = model == "lumi.gateway.mgl001" and fw >= "1.0.7_0019"
-                
-                # Core read steps, fail directly if they fail
+
                 await self.base_read_device(info)
                 await self.lumi_read_devices(sh)
                 await self.silabs_read_device(sh)
                 await self.openmiio_prepare_gateway(sh)
-                
-                # Non-critical reads, wrapped in try-except to avoid total failure
+
                 if support_ble_mesh:
                     try:
                         await self.ble_read_devices(sh)
@@ -145,14 +130,13 @@ class MultiGateway(
                         await self.mesh_read_devices(sh)
                     except Exception as e:
                         self.warning(f"Failed to read Mesh devices: {e}", exc_info=True)
-                        
+                
                 if support_matter:
                     try:
                         await self.matter_read_devices(sh)
                     except Exception as e:
                         self.warning(f"Failed to read Matter devices: {e}", exc_info=True)
 
-                # Register event listeners (only once per instance lifecycle)
                 if not self._listeners_added:
                     self.add_event_listener(EVENT_MQTT_PUBLISH, self.lumi_on_mqtt_publish)
                     self.add_event_listener(EVENT_MQTT_PUBLISH, self.miot_on_mqtt_publish)
@@ -164,28 +148,25 @@ class MultiGateway(
                         self.add_event_listener(EVENT_MQTT_PUBLISH, self.mesh_on_mqtt_publish)
                     if support_matter:
                         self.add_event_listener(EVENT_MQTT_PUBLISH, self.matter_on_mqtt_publish)
-                        
+                    
                     self.add_event_listener(EVENT_TIMER, self.openmiio_on_timer)
                     self.add_event_listener(EVENT_TIMER, self.silabs_on_timer)
                     
                     self._listeners_added = True
                     self.debug("Event listeners registered")
-
+                
                 return True
         except Exception as e:
             self.debug("Can't prepare gateway", exc_info=e)
-            # Reset listener flag so it can retry registration on the next attempt
             self._listeners_added = False
             return False
 
     async def send(self, device: XDevice, data: dict):
-        # Add device None check
         if device is None:
             self.debug("Send called with None device, ignoring")
             return
             
         if device.type == GATEWAY:
-            # Support multispec in lumi and miot formats
             if "cmd" in data and "method" in data:
                 lumi_data = {
                     "cmd": data["cmd"],
@@ -202,9 +183,7 @@ class MultiGateway(
                 await self.lumi_send(device, data)
             elif "method" in data:
                 await self.miot_send(device, data)
-                
         elif device.type == ZIGBEE:
-            # Support multispec in lumi and silabs format
             if "cmd" in data and "commands" in data:
                 lumi_data = {"cmd": data["cmd"], "did": data["did"]}
                 if "params" in data:
@@ -218,13 +197,11 @@ class MultiGateway(
                 await self.lumi_send(device, data)
             elif "commands" in data:
                 await self.silabs_send(device, data)
-                
         elif device.type in (MESH, GROUP):
             await self.miot_send(device, data)
         elif device.type == MATTER:
             await self.matter_send(device, data)
         else:
-            # Log unsupported device types for easier debugging
             self.debug(f"Send command not supported for device type: {device.type}", device=device)
 
     async def telnet_command(self, cmd: str) -> bool | None:

--- a/custom_components/xiaomi_gateway3/core/gateway.py
+++ b/custom_components/xiaomi_gateway3/core/gateway.py
@@ -1,5 +1,4 @@
 import asyncio
-
 from . import core_utils
 from .const import GATEWAY, GROUP, MATTER, MESH, ZIGBEE
 from .device import XDevice
@@ -25,6 +24,12 @@ class MultiGateway(
 ):
     main_task: asyncio.Task | None = None
 
+    def __init__(self, *args, **kwargs):
+        # Call all parent __init__ methods (handled automatically by MRO)
+        super().__init__(*args, **kwargs)
+        # Initialize instance flag to prevent duplicate listener registration
+        self._listeners_added = False
+
     def start(self):
         if self.main_task:
             return
@@ -34,37 +39,70 @@ class MultiGateway(
     async def stop(self):
         if not self.main_task:
             return
-
         self.debug("stop")
-        # wait main task for finished: mqtt disconnect and gateway available false
-        # updated for all devices
-        while not self.main_task.cancelled():
-            self.main_task.cancel()
-            await asyncio.sleep(0.1)
+        task = self.main_task
         self.main_task = None
+        task.cancel()
+        try:
+            # Wait for the task to finish gracefully, with a 5-second timeout
+            await asyncio.wait_for(task, timeout=5.0)
+        except asyncio.CancelledError:
+            pass  # Expected cancellation
+        except asyncio.TimeoutError:
+            self.warning("Main task did not stop within 5 seconds, forcing cancellation.")
+            # Force cancel again and wait a short time
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=1.0)
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                self.debug("Exception during force cancellation", exc_info=e)
+        except Exception as e:
+            self.debug("Exception during main task shutdown", exc_info=e)
 
     async def run_forever(self):
         while True:
-            # check if telnet port OK
-            if not await core_utils.check_port(self.host, 23):
-                if not await self.enable_telnet():
-                    await asyncio.sleep(30)
+            try:
+                # Check if telnet port is OK
+                if not await core_utils.check_port(self.host, 23):
+                    if not await self.enable_telnet():
+                        await asyncio.sleep(30)
+                        continue
+                
+                if not await self.prepare_gateway():
+                    await asyncio.sleep(60)
                     continue
-
-            if not await self.prepare_gateway():
-                await asyncio.sleep(60)
-                continue
-
-            await self.handle_mqtt_messages()
+                
+                # Handle MQTT messages, catch exceptions and cooldown before retrying
+                try:
+                    await self.handle_mqtt_messages()
+                except asyncio.CancelledError:
+                    raise  # Propagate cancellation signal to stop the task
+                except Exception as e:
+                    self.warning(f"MQTT handler crashed, reconnecting in 10s: {e}", exc_info=e)
+                    await asyncio.sleep(10)  # Cooldown to prevent busy loop
+                    
+            except asyncio.CancelledError:
+                # Ensure the outer loop also responds to cancellation
+                self.debug("run_forever cancelled, exiting")
+                raise
+            except Exception as e:
+                # Catch unexpected outer exceptions, log them, and restart the loop
+                self.error(f"Unexpected error in run_forever loop: {e}", exc_info=True)
+                await asyncio.sleep(10)
 
     async def enable_telnet(self) -> bool:
         """Enable telnet with miio protocol."""
         if not (token := self.options.get("token")):
             return False
+        
+        key = self.options.get("key")
+        if key is None:
+            self.debug("No key provided, assuming it's not required for telnet enable")
+            
         try:
-            resp = await core_utils.enable_telnet(
-                self.host, token, self.options.get("key")
-            )
+            resp = await core_utils.enable_telnet(self.host, token, key)
             self.debug("enable_telnet", data=resp)
             return resp == "ok"
         except Exception as e:
@@ -77,55 +115,77 @@ class MultiGateway(
                 if not await sh.only_one():
                     self.debug("Connection from a second Hass detected")
                     return False
-
+                
                 info = await sh.get_miio_info()
                 model, fw = info["model"], info["version"]
-
+                
                 if model == "lumi.gateway.mgl03" and fw < "1.4.7_0160":
                     self.warning(f"Unsupported firmware: {info}")
-
+                
                 support_ble_mesh = model in (
                     "lumi.gateway.mgl03",
                     "lumi.gateway.mcn001",
                     "lumi.gateway.mgl001",
                 )
                 support_matter = model == "lumi.gateway.mgl001" and fw >= "1.0.7_0019"
-
+                
+                # Core read steps, fail directly if they fail
                 await self.base_read_device(info)
                 await self.lumi_read_devices(sh)
                 await self.silabs_read_device(sh)
                 await self.openmiio_prepare_gateway(sh)
-
+                
+                # Non-critical reads, wrapped in try-except to avoid total failure
                 if support_ble_mesh:
-                    await self.ble_read_devices(sh)
-                    await self.mesh_read_devices(sh)
-
+                    try:
+                        await self.ble_read_devices(sh)
+                    except Exception as e:
+                        self.warning(f"Failed to read BLE devices: {e}", exc_info=True)
+                    try:
+                        await self.mesh_read_devices(sh)
+                    except Exception as e:
+                        self.warning(f"Failed to read Mesh devices: {e}", exc_info=True)
+                        
                 if support_matter:
-                    await self.matter_read_devices(sh)
+                    try:
+                        await self.matter_read_devices(sh)
+                    except Exception as e:
+                        self.warning(f"Failed to read Matter devices: {e}", exc_info=True)
 
-            self.add_event_listener(EVENT_MQTT_PUBLISH, self.lumi_on_mqtt_publish)
-            self.add_event_listener(EVENT_MQTT_PUBLISH, self.miot_on_mqtt_publish)
-            self.add_event_listener(EVENT_MQTT_PUBLISH, self.openmiio_on_mqtt_publish)
-            self.add_event_listener(EVENT_MQTT_PUBLISH, self.silabs_on_mqtt_publish)
+                # Register event listeners (only once per instance lifecycle)
+                if not self._listeners_added:
+                    self.add_event_listener(EVENT_MQTT_PUBLISH, self.lumi_on_mqtt_publish)
+                    self.add_event_listener(EVENT_MQTT_PUBLISH, self.miot_on_mqtt_publish)
+                    self.add_event_listener(EVENT_MQTT_PUBLISH, self.openmiio_on_mqtt_publish)
+                    self.add_event_listener(EVENT_MQTT_PUBLISH, self.silabs_on_mqtt_publish)
+                    
+                    if support_ble_mesh:
+                        self.add_event_listener(EVENT_MQTT_PUBLISH, self.ble_on_mqtt_publish)
+                        self.add_event_listener(EVENT_MQTT_PUBLISH, self.mesh_on_mqtt_publish)
+                    if support_matter:
+                        self.add_event_listener(EVENT_MQTT_PUBLISH, self.matter_on_mqtt_publish)
+                        
+                    self.add_event_listener(EVENT_TIMER, self.openmiio_on_timer)
+                    self.add_event_listener(EVENT_TIMER, self.silabs_on_timer)
+                    
+                    self._listeners_added = True
+                    self.debug("Event listeners registered")
 
-            if support_ble_mesh:
-                self.add_event_listener(EVENT_MQTT_PUBLISH, self.ble_on_mqtt_publish)
-                self.add_event_listener(EVENT_MQTT_PUBLISH, self.mesh_on_mqtt_publish)
-
-            if support_matter:
-                self.add_event_listener(EVENT_MQTT_PUBLISH, self.matter_on_mqtt_publish)
-
-            self.add_event_listener(EVENT_TIMER, self.openmiio_on_timer)
-            self.add_event_listener(EVENT_TIMER, self.silabs_on_timer)
-
-            return True
+                return True
         except Exception as e:
             self.debug("Can't prepare gateway", exc_info=e)
+            # Reset listener flag so it can retry registration on the next attempt
+            self._listeners_added = False
             return False
 
     async def send(self, device: XDevice, data: dict):
+        # Add device None check
+        if device is None:
+            self.debug("Send called with None device, ignoring")
+            return
+            
         if device.type == GATEWAY:
-            # support multispec in lumi and miot formats
+            # Support multispec in lumi and miot formats
             if "cmd" in data and "method" in data:
                 lumi_data = {
                     "cmd": data["cmd"],
@@ -142,9 +202,9 @@ class MultiGateway(
                 await self.lumi_send(device, data)
             elif "method" in data:
                 await self.miot_send(device, data)
-
+                
         elif device.type == ZIGBEE:
-            # support multispec in lumi and silabs format
+            # Support multispec in lumi and silabs format
             if "cmd" in data and "commands" in data:
                 lumi_data = {"cmd": data["cmd"], "did": data["did"]}
                 if "params" in data:
@@ -158,11 +218,14 @@ class MultiGateway(
                 await self.lumi_send(device, data)
             elif "commands" in data:
                 await self.silabs_send(device, data)
-
+                
         elif device.type in (MESH, GROUP):
             await self.miot_send(device, data)
         elif device.type == MATTER:
             await self.matter_send(device, data)
+        else:
+            # Log unsupported device types for easier debugging
+            self.debug(f"Send command not supported for device type: {device.type}", device=device)
 
     async def telnet_command(self, cmd: str) -> bool | None:
         self.debug("telnet_command", data=cmd)
@@ -187,6 +250,9 @@ class MultiGateway(
                 elif cmd == "unlock_firmware":
                     await sh.lock_firmware(False)
                     return await sh.check_firmware_lock() is False
-
+                else:
+                    self.debug(f"Unknown telnet command: {cmd}")
+                    return False
         except Exception as e:
             self.error(f"Can't run telnet command: {cmd}", exc_info=e)
+            return False


### PR DESCRIPTION
## 📝 Summary

This PR addresses several critical bugs and deep-seated architectural flaws across three core modules: `xiaomi_cloud.py`#1759, `add_entitites.py`#1757, and `gateway.py`#1760. 

The fixes resolve the `NameError` crash introduced in v4.2.0, eliminate multi-account state cross-contamination, fix async race conditions in entity registration, prevent gateway event-loop deadlocks, and implement full failover support for multi-server requests.

---

## 🌩️ 1. `xiaomi_cloud.py`#1759 (Cloud API Module)

### 🚨 Critical Fixes
1. **Fixed Multi-Account Cross-Contamination**: 
   Moved `auth`, `cookies`, `ssecurity`, and `devices` from **class variables** to **instance variables** in `__init__`. Previously, multiple `MiCloud` instances shared the same state, causing severe cross-contamination and login failures when users configured multiple Xiaomi accounts or when background token refreshes occurred concurrently.
2. **Removed Dangerous `assert` Statements**: 
   Replaced all `assert` checks (e.g., `assert res1["code"] == 0`) with explicit `if ... raise Exception(...)`. Python's `assert` is ignored in optimized mode (`-O`), which could lead to silent logic bypasses and obscure `KeyError` crashes downstream.
3. **Restored `login_captcha` Dual-Branch Logic**: 
   Fixed a regression where secondary 2FA captchas and initial graphical captchas were conflated. The logic now correctly handles both scenarios while adding `None` defenses.

### 🛡️ Robustness & Failover
4. **Full Multi-Server Failover Support**: 
   Added `try...except` blocks in `get_devices()`, `get_rooms()`, and `get_bindkey()`. If a regional server (e.g., `cn`) fails or returns an API error, the loop now safely logs a warning and continues to the next server, preventing the entire integration initialization from crashing.
5. **Defensive Unauthenticated Request Check**: 
   Added `if not self.ok:` at the beginning of `request()` to raise a clear `RuntimeError` instead of crashing with a `TypeError` inside the encryption function when `ssecurity` is missing.

---

## 🏠 2. `add_entitites.py`#1757 (Entity Registration Module)

### 🚨 Critical Fixes (v4.2.0 Regression & Edge Cases)
1. **Fixed `NameError` Crash**: 
   Replaced the undefined `add_entity(...)` call in `add_lazy_entity` with the correct inline async registration logic (`XEntity.ADD.get(...)`).
2. **Fixed `unique_id` Parsing Bug**: 
   Changed `split("_", 1)` to `rsplit("_", 1)`. If a device UID contains underscores (e.g., `lumi.gateway_1234`), the original `split` would truncate the UID and extract the wrong attribute. `rsplit` guarantees correct extraction from the right side.
3. **Resolved Async Race Condition**: 
   Deferred state updates using `hass.loop.call_soon(lambda e=entity, d=data: e.on_device_update(d))`. This ensures the entity is fully registered in the HA state machine before processing incoming data, preventing lost state updates. (Also used default arguments to avoid Python's late-binding closure trap).

### 🛡️ Robustness
4. **Prevented `StopIteration` & `RuntimeError`**: 
   Added a default `None` to `next((i for i in ...), None)` and used `lazy_attrs.copy()` during iteration to prevent the listener thread from dying or throwing `Set changed size during iteration` errors.
5. **Prevented `KeyError`**: 
   Used `XEntity.ADD.get(...)` instead of direct dictionary lookup, upgrading missing domains to `gw.warning()` instead of crashing the gateway.
6. **Improved Device Registry Cleanup**: 
   Adopted robust logic to properly identify the "main" device, migrate entities from duplicate/orphaned device records to the main device, and cleanly remove the empty records.

---

## 🚪 3. `gateway.py`#1760 (Gateway Lifecycle & Dispatch Module)

### 🚨 Critical Fixes
1. **Fixed `stop()` Deadlock / Infinite Loop**: 
   Replaced the dangerous `while not self.main_task.cancelled():` polling with `asyncio.wait_for(task, timeout=5.0)`. If a task catches `CancelledError` internally and doesn't re-raise it, the original code would cause an infinite loop, completely freezing the Home Assistant event loop upon integration unload.
2. **Prevented 100% CPU Busy Loop on MQTT Crash**: 
   Wrapped `handle_mqtt_messages()` in a `try...except` block with a 10-second cooldown `sleep`. If the MQTT connection drops unexpectedly, the gateway now gracefully retries instead of instantly hammering the CPU and network in a tight loop.
3. **Fixed Event Listener Memory Leak**: 
   Initialized an instance-level `_listeners_added` flag in `__init__`. This prevents event listeners from being registered multiple times when the gateway reconnects, which previously caused duplicate state updates and memory leaks.

### 🛡️ Robustness
4. **Non-Critical Read Isolation**: 
   Wrapped BLE, Mesh, and Matter device reads in independent `try...except` blocks. A failure in reading non-critical BLE devices no longer prevents Zigbee and MiOT devices from loading.
5. **Eliminated Silent Failures**: 
   Added `else` branches and explicit return values in `send()` and `telnet_command()` to log unsupported device types or unknown commands, making future debugging significantly easier.

---

## 🧪 Testing & Impact

- [x] Verified that multiple Xiaomi accounts can be logged in and refreshed concurrently without state leakage.
- [x] Verified that devices with lazy entities initialize successfully without `NameError`, `StopIteration`, or lost state updates.
- [x] Verified that devices with underscores in their `uid` correctly restore lazy entities from the registry.
- [x] Verified that if a regional Xiaomi server is down, the integration gracefully falls back to the next server.
- [x] Verified that unloading the integration no longer freezes the Home Assistant event loop.
- [x] Verified that MQTT disconnects trigger a cooldown retry instead of a 100% CPU busy loop.
- [x] Verified that gateway reconnects do not result in duplicate event listener registrations.

## 📋 Checklist
- [x] The code is tested and works locally.
- [x] No new warnings or errors are introduced.
- [x] Code follows the project's styling and logic patterns.
- [x] Significantly improves the robustness, concurrency, and stability of the integration.
